### PR TITLE
feat: ライブラリから書籍を自動切替して全冊一括キャプチャ

### DIFF
--- a/src/kindle_cap/cli.py
+++ b/src/kindle_cap/cli.py
@@ -5,6 +5,7 @@ import typer
 
 from .config import CaptureConfig, Direction
 from .orchestrator import run as orchestrator_run
+from .orchestrator import run_library as orchestrator_run_library
 from .pdf import build_pdf
 from .preflight import PreflightError
 
@@ -31,19 +32,52 @@ def capture(
         False, "--auto-stop",
         help="連続する 2 ページが同一なら書籍末尾と判断して停止",
     ),
+    from_library: bool = typer.Option(
+        False, "--from-library",
+        help="ライブラリ画面から書籍を順次クリック→撮影→閉じる、を繰り返す",
+    ),
+    max_books: int = typer.Option(
+        10, "--max-books",
+        help="--from-library 時の上限冊数",
+    ),
+    n_cols: int = typer.Option(
+        6, "--n-cols",
+        help="--from-library 時のグリッド列数（Kindle のウィンドウサイズに依存）",
+    ),
+    book_open_wait: float = typer.Option(
+        2.0, "--book-open-wait",
+        help="--from-library 時、本を開いた後の待機秒",
+    ),
+    library_open_wait: float = typer.Option(
+        1.0, "--library-open-wait",
+        help="--from-library 時、本を閉じてライブラリに戻った後の待機秒",
+    ),
 ) -> None:
-    if name is None:
+    # library モードでは name は連番固定なのでプロンプトしない
+    if not from_library and name is None:
         name = typer.prompt("書籍名 (出力ディレクトリ名)")
+
+    # library モードでは name はダミー（_capture_book 内で連番に置き換わる）
     config = CaptureConfig(
-        name=name,
+        name=(name or "library-loop"),
         pages=pages,
         direction=direction,
         wait=wait,
         out=out,
         keep_png=keep_png,
     )
+
     try:
-        orchestrator_run(config, dry_run=dry_run, auto_stop=auto_stop)
+        if from_library:
+            orchestrator_run_library(
+                config,
+                max_books=max_books,
+                n_cols=n_cols,
+                book_open_wait=book_open_wait,
+                library_open_wait=library_open_wait,
+            )
+        else:
+            orchestrator_run(config, dry_run=dry_run, auto_stop=auto_stop)
     except PreflightError as e:
         typer.echo(f"[エラー] {e}", err=True)
         raise typer.Exit(code=1)

--- a/src/kindle_cap/library.py
+++ b/src/kindle_cap/library.py
@@ -1,0 +1,79 @@
+"""Library mode: iterate over books in the Kindle library grid.
+
+Kindle.app のライブラリ画面はカバー画像のグリッドで構成される。本モジュールは
+グリッドの各セル中央のスクリーン座標を計算し、System Events 経由でクリック
+することで「次の本を開く」自動化を可能にする。
+"""
+import subprocess
+
+from .config import Geometry
+
+
+def compute_book_positions(
+    window_geom: Geometry,
+    n_cols: int = 6,
+    top_padding: int = 80,
+    bottom_padding: int = 50,
+    left_padding: int = 30,
+    right_padding: int = 30,
+    row_height: int = 240,
+) -> list[tuple[int, int]]:
+    """ライブラリ画面の各書籍カバーの中央座標を返す。
+
+    Args:
+        window_geom: Kindle ウィンドウの位置とサイズ（仮想スクリーン座標系）
+        n_cols: 1 行あたりの書籍数（Kindle.app のウィンドウサイズに依存）
+        top_padding: タブバー＋フィルタバー分の上端余白
+        bottom_padding: 下部タブバー分の下端余白
+        left_padding / right_padding: 左右の余白
+        row_height: 書籍カバー 1 行分の高さ（カバー縦サイズ + ギャップ）
+
+    Returns:
+        画面に表示される全セルの (x, y) リスト。左から右、上から下の順。
+    """
+    if n_cols <= 0:
+        raise ValueError("n_cols must be positive")
+
+    inner_width = window_geom.width - left_padding - right_padding
+    if inner_width <= 0:
+        raise ValueError("window too narrow for given paddings")
+
+    cell_width = inner_width / n_cols
+
+    inner_height = window_geom.height - top_padding - bottom_padding
+    n_rows = max(0, inner_height // row_height)
+
+    positions: list[tuple[int, int]] = []
+    for row in range(n_rows):
+        for col in range(n_cols):
+            x = window_geom.x + left_padding + int(cell_width * (col + 0.5))
+            y = window_geom.y + top_padding + int(row_height * (row + 0.5))
+            positions.append((x, y))
+    return positions
+
+
+def click_at(x: int, y: int) -> None:
+    """指定スクリーン座標を Kindle プロセス内でクリックする。"""
+    script = (
+        f'tell application "System Events" to tell process "Kindle" '
+        f"to click at {{{x}, {y}}}"
+    )
+    subprocess.run(["osascript", "-e", script], check=True)
+
+
+def close_book() -> None:
+    """Cmd+W で現在の本を閉じてライブラリに戻る。"""
+    script = (
+        'tell application "System Events" to tell process "Kindle" '
+        'to keystroke "w" using command down'
+    )
+    subprocess.run(["osascript", "-e", script], check=True)
+
+
+def back_to_library() -> None:
+    """Cmd+L でライブラリ画面に戻る（保険）。"""
+    script = (
+        'tell application "System Events" to tell process "Kindle" '
+        'to keystroke "l" using command down'
+    )
+    subprocess.run(["osascript", "-e", script], check=True)

--- a/src/kindle_cap/orchestrator.py
+++ b/src/kindle_cap/orchestrator.py
@@ -1,11 +1,13 @@
 """Orchestrate the capture loop, dry-run, and PDF assembly."""
 import hashlib
+from dataclasses import replace
 from pathlib import Path
 from time import sleep
 
 from .capture import capture_rect
 from .config import CaptureConfig
 from .keys import send_next_page
+from .library import click_at, close_book, compute_book_positions
 from .pdf import build_pdf
 from .preflight import preflight
 from .window import activate_kindle, get_window_geometry
@@ -23,6 +25,57 @@ def run(
         _run_dry(config)
         return
 
+    _capture_book(config, auto_stop=auto_stop)
+
+
+def run_library(
+    config: CaptureConfig,
+    max_books: int,
+    n_cols: int = 6,
+    book_open_wait: float = 2.0,
+    library_open_wait: float = 1.0,
+) -> None:
+    """ライブラリ画面から書籍を順次クリックして開き、それぞれ撮影する。
+
+    Args:
+        config: 撮影設定（name は連番に上書きされる）
+        max_books: ループする書籍数の上限
+        n_cols: ライブラリのグリッド列数
+        book_open_wait: 本を開いたあとの待機秒
+        library_open_wait: 本を閉じてライブラリに戻ったあとの待機秒
+    """
+    preflight()
+    config.out.mkdir(parents=True, exist_ok=True)
+
+    activate_kindle()
+    geom = get_window_geometry()
+    positions = compute_book_positions(geom, n_cols=n_cols)[:max_books]
+
+    print(f"=== ライブラリループ開始: {len(positions)} 冊 ===", flush=True)
+    try:
+        for i, (x, y) in enumerate(positions, 1):
+            book_name = f"book-{i:03d}"
+            print(
+                f"\n=== Book {i}/{len(positions)}: {book_name} (click {x},{y}) ===",
+                flush=True,
+            )
+            click_at(x, y)
+            sleep(book_open_wait)
+
+            single_config = replace(config, name=book_name)
+            _capture_book(single_config, auto_stop=True)
+
+            close_book()
+            sleep(library_open_wait)
+    except KeyboardInterrupt:
+        print("\n中断しました（ライブラリループ）", flush=True)
+        return
+
+    print(f"\n完了: {len(positions)} 冊", flush=True)
+
+
+def _capture_book(config: CaptureConfig, *, auto_stop: bool) -> None:
+    """preflight 抜きの単一書籍撮影。run / run_library から共有して使う。"""
     out_dir = config.out / config.name
     out_dir.mkdir(parents=True, exist_ok=True)
     _purge_old_pages(out_dir)
@@ -57,6 +110,10 @@ def run(
             f"\n中断しました。{len(captured)}/{config.pages} ページまで撮影済み。"
             " PNG は保持し、PDF は作成しません。"
         )
+        return
+
+    if not captured:
+        print(f"撮影 0 ページ。{config.name} の PDF はスキップ", flush=True)
         return
 
     pdf_path = config.out / f"{config.name}.pdf"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -121,6 +121,87 @@ def test_capture_no_keep_png(mock_run: MagicMock, tmp_path: Path) -> None:
     assert mock_run.call_args.args[0].keep_png is False
 
 
+@patch("kindle_cap.cli.orchestrator_run_library")
+def test_capture_from_library_invokes_run_library(
+    mock_run_library: MagicMock, tmp_path: Path,
+) -> None:
+    app = _make_app(capture)
+    result = runner.invoke(
+        app,
+        [
+            "--pages", "600",
+            "--direction", "rtl",
+            "--out", str(tmp_path),
+            "--from-library",
+            "--max-books", "5",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    mock_run_library.assert_called_once()
+    assert mock_run_library.call_args.kwargs.get("max_books") == 5
+
+
+@patch("kindle_cap.cli.orchestrator_run_library")
+def test_capture_from_library_passes_n_cols(
+    mock_run_library: MagicMock, tmp_path: Path,
+) -> None:
+    app = _make_app(capture)
+    result = runner.invoke(
+        app,
+        [
+            "--pages", "100",
+            "--direction", "rtl",
+            "--out", str(tmp_path),
+            "--from-library",
+            "--max-books", "3",
+            "--n-cols", "5",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert mock_run_library.call_args.kwargs.get("n_cols") == 5
+
+
+@patch("kindle_cap.cli.orchestrator_run_library")
+def test_capture_from_library_does_not_prompt_for_name(
+    mock_run_library: MagicMock, tmp_path: Path,
+) -> None:
+    """library モードでは name は連番なのでプロンプト不要"""
+    app = _make_app(capture)
+    result = runner.invoke(
+        app,
+        [
+            "--pages", "100",
+            "--direction", "rtl",
+            "--out", str(tmp_path),
+            "--from-library",
+            "--max-books", "2",
+        ],
+        input="",  # 入力空でもエラーにならない
+    )
+    assert result.exit_code == 0, result.output
+
+
+@patch("kindle_cap.cli.orchestrator_run")
+@patch("kindle_cap.cli.orchestrator_run_library")
+def test_capture_normal_mode_does_not_invoke_library(
+    mock_lib: MagicMock, mock_normal: MagicMock, tmp_path: Path,
+) -> None:
+    """--from-library が無いときは run、library は呼ばれない"""
+    app = _make_app(capture)
+    result = runner.invoke(
+        app,
+        [
+            "--name", "x",
+            "--pages", "5",
+            "--direction", "rtl",
+            "--out", str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    mock_normal.assert_called_once()
+    mock_lib.assert_not_called()
+
+
 @patch("kindle_cap.cli.build_pdf")
 def test_rebuild_pdf_writes_to_parent_with_dir_name(
     mock_build: MagicMock, tmp_path: Path,

--- a/tests/unit/test_library.py
+++ b/tests/unit/test_library.py
@@ -1,0 +1,187 @@
+"""Tests for library auto-switch functionality."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kindle_cap.config import Geometry
+from kindle_cap.library import (
+    back_to_library,
+    click_at,
+    close_book,
+    compute_book_positions,
+)
+
+
+# ---------------------------------------------------------------------------
+# 純粋関数 compute_book_positions: ライブラリのグリッド座標を計算
+# ---------------------------------------------------------------------------
+
+
+def test_compute_positions_returns_non_empty() -> None:
+    geom = Geometry(0, 0, 1440, 869)
+    assert len(compute_book_positions(geom, n_cols=6)) > 0
+
+
+def test_compute_positions_all_inside_window() -> None:
+    geom = Geometry(0, 0, 1440, 869)
+    for x, y in compute_book_positions(geom, n_cols=6):
+        assert 0 <= x <= 1440
+        assert 0 <= y <= 869
+
+
+def test_compute_positions_count_is_multiple_of_n_cols() -> None:
+    geom = Geometry(0, 0, 1440, 869)
+    positions = compute_book_positions(geom, n_cols=6)
+    assert len(positions) % 6 == 0
+
+
+def test_compute_positions_first_two_are_same_row_different_x() -> None:
+    geom = Geometry(0, 0, 1440, 869)
+    positions = compute_book_positions(geom, n_cols=6)
+    x1, y1 = positions[0]
+    x2, y2 = positions[1]
+    assert y1 == y2  # 同じ行
+    assert x2 > x1  # 右方向
+
+
+def test_compute_positions_row_break_at_n_cols() -> None:
+    geom = Geometry(0, 0, 1440, 869)
+    positions = compute_book_positions(geom, n_cols=6)
+    if len(positions) >= 7:
+        x1, y1 = positions[0]
+        x7, y7 = positions[6]
+        assert y7 > y1  # 次の行
+        assert x7 == x1  # 同じ列の x
+
+
+def test_compute_positions_respects_window_offset() -> None:
+    """外部ディスプレイにウィンドウがある場合 (x>0, y>0)"""
+    geom = Geometry(310, 1111, 1440, 869)
+    positions = compute_book_positions(geom, n_cols=6)
+    for x, y in positions:
+        assert x >= 310
+        assert y >= 1111
+        assert x < 310 + 1440
+        assert y < 1111 + 869
+
+
+def test_compute_positions_respects_negative_window_offset() -> None:
+    """マルチディスプレイ（外部モニタが左に配置）: x が負"""
+    geom = Geometry(-1920, 0, 1920, 1080)
+    positions = compute_book_positions(geom, n_cols=6)
+    for x, y in positions:
+        assert -1920 <= x < 0
+
+
+def test_compute_positions_n_cols_3_vs_6_same_window() -> None:
+    geom = Geometry(0, 0, 1440, 869)
+    p3 = compute_book_positions(geom, n_cols=3)
+    p6 = compute_book_positions(geom, n_cols=6)
+    rows_3 = len(p3) // 3
+    rows_6 = len(p6) // 6
+    assert rows_3 == rows_6
+    assert len(p6) == 2 * len(p3)
+
+
+def test_compute_positions_n_cols_zero_rejected() -> None:
+    geom = Geometry(0, 0, 1440, 869)
+    with pytest.raises(ValueError, match="n_cols"):
+        compute_book_positions(geom, n_cols=0)
+
+
+def test_compute_positions_n_cols_negative_rejected() -> None:
+    geom = Geometry(0, 0, 1440, 869)
+    with pytest.raises(ValueError, match="n_cols"):
+        compute_book_positions(geom, n_cols=-1)
+
+
+def test_compute_positions_too_narrow_window_rejected() -> None:
+    """パディング合計 > 幅 ならエラー"""
+    geom = Geometry(0, 0, 50, 869)
+    with pytest.raises(ValueError):
+        compute_book_positions(geom, n_cols=6, left_padding=30, right_padding=30)
+
+
+def test_compute_positions_short_window_returns_empty_list() -> None:
+    """高さが足りなくて 1 行分も入らないなら空"""
+    geom = Geometry(0, 0, 1440, 100)
+    positions = compute_book_positions(
+        geom, n_cols=6, top_padding=80, bottom_padding=50, row_height=240
+    )
+    assert positions == []
+
+
+def test_compute_positions_first_cell_is_within_top_padding_band() -> None:
+    """1行目の y は top_padding より下、かつ row_height より上"""
+    geom = Geometry(0, 0, 1440, 869)
+    positions = compute_book_positions(
+        geom, n_cols=6, top_padding=80, row_height=240
+    )
+    _, y_first = positions[0]
+    assert y_first >= 80
+    assert y_first < 80 + 240
+
+
+def test_compute_positions_first_cell_is_within_left_padding_band() -> None:
+    """1列目の x は left_padding より右、cell_width 内"""
+    geom = Geometry(0, 0, 1440, 869)
+    positions = compute_book_positions(
+        geom, n_cols=6, left_padding=30, right_padding=30
+    )
+    x_first, _ = positions[0]
+    cell_width = (1440 - 60) / 6
+    assert x_first >= 30
+    assert x_first < 30 + cell_width
+
+
+# ---------------------------------------------------------------------------
+# 薄ラッパー click_at / close_book / back_to_library
+# ---------------------------------------------------------------------------
+
+
+@patch("kindle_cap.library.subprocess.run")
+def test_click_at_invokes_osascript_with_coords(mock_run: MagicMock) -> None:
+    click_at(123, 456)
+    cmd = mock_run.call_args[0][0]
+    assert cmd[0] == "osascript"
+    assert cmd[1] == "-e"
+    assert "{123, 456}" in cmd[2]
+    assert "click at" in cmd[2]
+
+
+@patch("kindle_cap.library.subprocess.run")
+def test_click_at_targets_kindle_process(mock_run: MagicMock) -> None:
+    click_at(0, 0)
+    cmd = mock_run.call_args[0][0]
+    assert 'process "Kindle"' in cmd[2]
+
+
+@patch("kindle_cap.library.subprocess.run")
+def test_click_at_uses_check_true(mock_run: MagicMock) -> None:
+    click_at(100, 100)
+    assert mock_run.call_args.kwargs.get("check") is True
+
+
+@patch("kindle_cap.library.subprocess.run")
+def test_click_at_handles_negative_coords(mock_run: MagicMock) -> None:
+    """マルチディスプレイ環境で負の座標もそのまま渡す"""
+    click_at(-1500, -200)
+    cmd = mock_run.call_args[0][0]
+    assert "{-1500, -200}" in cmd[2]
+
+
+@patch("kindle_cap.library.subprocess.run")
+def test_close_book_sends_cmd_w(mock_run: MagicMock) -> None:
+    close_book()
+    cmd = mock_run.call_args[0][0]
+    assert 'keystroke "w"' in cmd[2]
+    assert "command down" in cmd[2]
+    assert 'process "Kindle"' in cmd[2]
+
+
+@patch("kindle_cap.library.subprocess.run")
+def test_back_to_library_sends_cmd_l(mock_run: MagicMock) -> None:
+    back_to_library()
+    cmd = mock_run.call_args[0][0]
+    assert 'keystroke "l"' in cmd[2]
+    assert "command down" in cmd[2]

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from kindle_cap.config import CaptureConfig, Direction, Geometry
-from kindle_cap.orchestrator import run
+from kindle_cap.orchestrator import run, run_library
 
 _GEOM = Geometry(x=0, y=0, width=100, height=100)
 
@@ -282,3 +282,192 @@ def test_run_auto_stop_with_all_unique_pages_takes_full_count(
     mock_cap.side_effect = _all_unique
     run(_config(tmp_path, pages=5), auto_stop=True)
     assert mock_pdf.call_args[0][0].__len__() == 5
+
+
+# ---------------------------------------------------------------------------
+# run_library: ライブラリから本を順次開いて撮影
+# ---------------------------------------------------------------------------
+
+
+_LIBRARY_GEOM = Geometry(x=0, y=0, width=1440, height=869)
+
+
+@patch("kindle_cap.orchestrator.close_book")
+@patch("kindle_cap.orchestrator.click_at")
+@patch("kindle_cap.orchestrator.compute_book_positions")
+@patch("kindle_cap.orchestrator.build_pdf")
+@patch("kindle_cap.orchestrator.send_next_page")
+@patch("kindle_cap.orchestrator.capture_rect")
+@patch("kindle_cap.orchestrator.get_window_geometry")
+@patch("kindle_cap.orchestrator.activate_kindle")
+@patch("kindle_cap.orchestrator.preflight")
+def test_run_library_clicks_each_position_in_order(
+    mock_pre, mock_act, mock_geom, mock_cap, mock_send, mock_pdf,
+    mock_compute, mock_click, mock_close, tmp_path,
+):
+    positions = [(100, 200), (300, 200), (500, 200)]
+    mock_compute.return_value = positions
+    mock_geom.return_value = _LIBRARY_GEOM
+
+    # auto-stop で 1 ページ目で停止するよう、capture が常に同じ内容を書く
+    counter = {"n": 0}
+
+    def _dup(geom, path):
+        counter["n"] += 1
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"same-content")  # 全部同一 → auto-stop 即発火
+
+    mock_cap.side_effect = _dup
+    run_library(_config(tmp_path), max_books=3, book_open_wait=0.0,
+                library_open_wait=0.0)
+
+    assert mock_click.call_count == 3
+    assert [call.args for call in mock_click.call_args_list] == [
+        (100, 200), (300, 200), (500, 200),
+    ]
+
+
+@patch("kindle_cap.orchestrator.close_book")
+@patch("kindle_cap.orchestrator.click_at")
+@patch("kindle_cap.orchestrator.compute_book_positions")
+@patch("kindle_cap.orchestrator.build_pdf")
+@patch("kindle_cap.orchestrator.send_next_page")
+@patch("kindle_cap.orchestrator.capture_rect")
+@patch("kindle_cap.orchestrator.get_window_geometry")
+@patch("kindle_cap.orchestrator.activate_kindle")
+@patch("kindle_cap.orchestrator.preflight")
+def test_run_library_closes_book_after_each_capture(
+    mock_pre, mock_act, mock_geom, mock_cap, mock_send, mock_pdf,
+    mock_compute, mock_click, mock_close, tmp_path,
+):
+    mock_compute.return_value = [(100, 200), (300, 200)]
+    mock_geom.return_value = _LIBRARY_GEOM
+
+    def _dup(geom, path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"same")
+
+    mock_cap.side_effect = _dup
+    run_library(_config(tmp_path), max_books=2, book_open_wait=0.0,
+                library_open_wait=0.0)
+    assert mock_close.call_count == 2
+
+
+@patch("kindle_cap.orchestrator.close_book")
+@patch("kindle_cap.orchestrator.click_at")
+@patch("kindle_cap.orchestrator.compute_book_positions")
+@patch("kindle_cap.orchestrator.build_pdf")
+@patch("kindle_cap.orchestrator.send_next_page")
+@patch("kindle_cap.orchestrator.capture_rect")
+@patch("kindle_cap.orchestrator.get_window_geometry")
+@patch("kindle_cap.orchestrator.activate_kindle")
+@patch("kindle_cap.orchestrator.preflight")
+def test_run_library_max_books_caps_iteration(
+    mock_pre, mock_act, mock_geom, mock_cap, mock_send, mock_pdf,
+    mock_compute, mock_click, mock_close, tmp_path,
+):
+    """positions が 10 個あっても max_books=3 なら 3 冊で止まる"""
+    mock_compute.return_value = [(i * 100, 200) for i in range(10)]
+    mock_geom.return_value = _LIBRARY_GEOM
+
+    def _dup(geom, path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"same")
+
+    mock_cap.side_effect = _dup
+    run_library(_config(tmp_path), max_books=3, book_open_wait=0.0,
+                library_open_wait=0.0)
+    assert mock_click.call_count == 3
+
+
+@patch("kindle_cap.orchestrator.close_book")
+@patch("kindle_cap.orchestrator.click_at")
+@patch("kindle_cap.orchestrator.compute_book_positions")
+@patch("kindle_cap.orchestrator.build_pdf")
+@patch("kindle_cap.orchestrator.send_next_page")
+@patch("kindle_cap.orchestrator.capture_rect")
+@patch("kindle_cap.orchestrator.get_window_geometry")
+@patch("kindle_cap.orchestrator.activate_kindle")
+@patch("kindle_cap.orchestrator.preflight")
+def test_run_library_creates_separate_pdf_per_book(
+    mock_pre, mock_act, mock_geom, mock_cap, mock_send, mock_pdf,
+    mock_compute, mock_click, mock_close, tmp_path,
+):
+    mock_compute.return_value = [(100, 200), (300, 200)]
+    mock_geom.return_value = _LIBRARY_GEOM
+
+    def _dup(geom, path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"same")
+
+    mock_cap.side_effect = _dup
+    run_library(_config(tmp_path), max_books=2, book_open_wait=0.0,
+                library_open_wait=0.0)
+
+    pdf_paths = [call.args[1] for call in mock_pdf.call_args_list]
+    # 各 PDF は book-001.pdf, book-002.pdf 形式で out_root に
+    pdf_names = sorted(p.name for p in pdf_paths)
+    assert pdf_names == ["book-001.pdf", "book-002.pdf"]
+
+
+@patch("kindle_cap.orchestrator.close_book")
+@patch("kindle_cap.orchestrator.click_at")
+@patch("kindle_cap.orchestrator.compute_book_positions")
+@patch("kindle_cap.orchestrator.build_pdf")
+@patch("kindle_cap.orchestrator.send_next_page")
+@patch("kindle_cap.orchestrator.capture_rect")
+@patch("kindle_cap.orchestrator.get_window_geometry")
+@patch("kindle_cap.orchestrator.activate_kindle")
+@patch("kindle_cap.orchestrator.preflight")
+def test_run_library_runs_preflight_once(
+    mock_pre, mock_act, mock_geom, mock_cap, mock_send, mock_pdf,
+    mock_compute, mock_click, mock_close, tmp_path,
+):
+    """3 冊撮るのに preflight は 1 回だけ"""
+    mock_compute.return_value = [(100, 200), (300, 200), (500, 200)]
+    mock_geom.return_value = _LIBRARY_GEOM
+
+    def _dup(geom, path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"same")
+
+    mock_cap.side_effect = _dup
+    run_library(_config(tmp_path), max_books=3, book_open_wait=0.0,
+                library_open_wait=0.0)
+    assert mock_pre.call_count == 1
+
+
+@patch("kindle_cap.orchestrator.close_book")
+@patch("kindle_cap.orchestrator.click_at")
+@patch("kindle_cap.orchestrator.compute_book_positions")
+@patch("kindle_cap.orchestrator.build_pdf")
+@patch("kindle_cap.orchestrator.send_next_page")
+@patch("kindle_cap.orchestrator.capture_rect")
+@patch("kindle_cap.orchestrator.get_window_geometry")
+@patch("kindle_cap.orchestrator.activate_kindle")
+@patch("kindle_cap.orchestrator.preflight")
+def test_run_library_keyboard_interrupt_stops_loop(
+    mock_pre, mock_act, mock_geom, mock_cap, mock_send, mock_pdf,
+    mock_compute, mock_click, mock_close, tmp_path,
+):
+    mock_compute.return_value = [(i * 100, 200) for i in range(5)]
+    mock_geom.return_value = _LIBRARY_GEOM
+
+    # 撮影自体は同一内容で auto-stop 即発火させる
+    def _dup(geom, path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"same")
+
+    mock_cap.side_effect = _dup
+
+    # 2 冊目の click で Ctrl-C
+    def _click_then_interrupt(x, y):
+        if mock_click.call_count == 2:
+            raise KeyboardInterrupt()
+
+    mock_click.side_effect = _click_then_interrupt
+
+    run_library(_config(tmp_path), max_books=5, book_open_wait=0.0,
+                library_open_wait=0.0)
+    # 5 冊全部はクリックされない（中断あり）
+    assert mock_click.call_count < 5


### PR DESCRIPTION
Closes #3

## Summary

- Kindle ライブラリ画面のグリッドに並んだ書籍を順次クリックして開き、auto-stop で末尾まで撮影、Cmd+W で閉じて次の本、を繰り返す `--from-library` モードを追加
- 純粋関数 `compute_book_positions` を切り出して mock なしで境界値検証
- `_capture_book` を切り出して `run` と `run_library` で共有

## 主な追加項目

- `src/kindle_cap/library.py`: グリッド座標計算 + System Events ラッパー
- `orchestrator.run_library`: preflight 1回 → 各書籍の click → 撮影 → close
- CLI: `--from-library`, `--max-books`, `--n-cols`, `--book-open-wait`, `--library-open-wait`

## Test plan

- [x] unit 184 + live 15 全 pass (\`uv run pytest\`)
- [ ] 実機で 5 冊一括キャプチャを確認（次セッション）
- [ ] グリッド定数の調整（実機の Kindle UI で top_padding/row_height が合っているか）