### PR TITLE
feat: --auto-direction で direction 自動判定 (closes #15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 
+- `--auto-direction`：表紙起点で試写し、ページ綴じ方向（rtl/ltr）を自動判定。試写 3 枚は本番に流用するため重複撮影しない（issue #15）
 - 開発者向けドキュメント（`CHANGELOG.md`、`CONTRIBUTING.md`）
 - GitHub の Issue / Pull Request テンプレート（`.github/`）
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,15 @@ uv sync
 
 ```bash
 # 1. Kindle.app で書籍を開き、表紙ページを表示する（Cmd+G で先頭ジャンプも可）
-# 2. 撮影実行
+# 2. 撮影実行（direction を自動判定する場合）
+uv run kindle-cap \
+  --name my-book \
+  --pages 600 \
+  --auto-direction \
+  --auto-stop \
+  --wait 1.5
+
+# 明示指定（rtl/ltr が分かっている場合）
 uv run kindle-cap \
   --name my-book \
   --pages 600 \
@@ -88,7 +96,8 @@ output/my-book.pdf
 | オプション | 必須 | デフォルト | 説明 |
 |---|---|---|---|
 | `--pages N` | ✓ | — | 撮影ページ数の上限 |
-| `--direction rtl\|ltr` | ✓ | — | `rtl`=右綴じ（右矢印で次ページ）、`ltr`=左綴じ（左矢印で次ページ） |
+| `--direction rtl\|ltr` | ※ | — | `rtl`=右綴じ（右矢印で次ページ）、`ltr`=左綴じ（左矢印で次ページ） |
+| `--auto-direction` | ※ | off | 表紙起点で direction を試写判定。試写は本番に流用（重複撮影なし） |
 | `--name NAME` | | （対話プロンプト） | 出力ディレクトリ名 |
 | `--wait SEC` | | `1.0` | ページ送り後の待機秒（重い書籍は `1.5` 推奨） |
 | `--out PATH` | | `./output` | 出力先 |
@@ -96,8 +105,11 @@ output/my-book.pdf
 | `--dry-run` | | off | 1 枚だけ撮って位置確認用に保存（PDF は作らない） |
 | `--auto-stop` | | off | 連続する 2 ページが同一なら書籍末尾と判断して停止 |
 
+※ `--direction` または `--auto-direction` のいずれかが必須（同時指定はエラー）
+
 > [!IMPORTANT]
-> **direction についての注意**: Kindle for Mac 上の `direction` は紙の綴じ方向と必ずしも一致しない。リフロー型の和書（縦書き）でも左矢印で次ページ（`ltr`）になるケースがある。`--dry-run` で 1 枚撮影 → 矢印キーを 1 回手動で押してページが進むか確認、で判定するのを推奨。
+> **direction についての注意**: Kindle for Mac 上の `direction` は紙の綴じ方向と必ずしも一致しない。リフロー型の和書（縦書き）でも左矢印で次ページ（`ltr`）になるケースがある。
+> **推奨**: `--auto-direction` で表紙起点の試写による自動判定を使う（`--dry-run` で当てっこする手間が消える）。明示指定したい場合は従来通り `--direction rtl|ltr` も使える。
 
 ### 既存 PNG から PDF だけ再生成
 

--- a/src/kindle_cap/cli.py
+++ b/src/kindle_cap/cli.py
@@ -12,11 +12,16 @@ from .preflight import PreflightError
 
 def capture(
     pages: int = typer.Option(..., "--pages", help="撮影ページ数"),
-    direction: Direction = typer.Option(
-        ...,
+    direction: Direction | None = typer.Option(
+        None,
         "--direction",
-        help="rtl=右綴じ、ltr=左綴じ",
+        help="rtl=右綴じ、ltr=左綴じ（--auto-direction を使う場合は不要）",
         case_sensitive=False,
+    ),
+    auto_direction: bool = typer.Option(
+        False,
+        "--auto-direction",
+        help="表紙起点で direction を試写判定（rtl/ltr の手動指定が不要）",
     ),
     name: str = typer.Option(
         None,
@@ -41,6 +46,17 @@ def capture(
         help="連続する 2 ページが同一なら書籍末尾と判断して停止",
     ),
 ) -> None:
+    if direction is not None and auto_direction:
+        raise typer.BadParameter(
+            "--direction と --auto-direction は同時指定できません",
+            param_hint="--direction / --auto-direction",
+        )
+    if direction is None and not auto_direction:
+        raise typer.BadParameter(
+            "--direction または --auto-direction のいずれかを指定してください",
+            param_hint="--direction / --auto-direction",
+        )
+
     if name is None:
         name = typer.prompt("書籍名 (出力ディレクトリ名)")
 
@@ -54,7 +70,12 @@ def capture(
     )
 
     try:
-        orchestrator_run(config, dry_run=dry_run, auto_stop=auto_stop)
+        orchestrator_run(
+            config,
+            dry_run=dry_run,
+            auto_stop=auto_stop,
+            auto_direction=auto_direction,
+        )
     except PreflightError as e:
         typer.echo(f"[エラー] {e}", err=True)
         raise typer.Exit(code=1) from e

--- a/src/kindle_cap/config.py
+++ b/src/kindle_cap/config.py
@@ -22,7 +22,7 @@ class Geometry:
 class CaptureConfig:
     name: str
     pages: int
-    direction: Direction
+    direction: Direction | None
     wait: float
     out: Path
     keep_png: bool

--- a/src/kindle_cap/orchestrator.py
+++ b/src/kindle_cap/orchestrator.py
@@ -28,6 +28,10 @@ def run(
     _capture_book(config, auto_stop=auto_stop)
 
 
+def _image_hash(path: Path) -> str:
+    return hashlib.md5(path.read_bytes()).hexdigest()
+
+
 def _capture_book(config: CaptureConfig, *, auto_stop: bool) -> None:
     """preflight 抜きの単一書籍撮影。"""
     out_dir = config.out / config.name
@@ -45,7 +49,7 @@ def _capture_book(config: CaptureConfig, *, auto_stop: bool) -> None:
             capture_rect(geom, png_path)
 
             if auto_stop:
-                current_hash = hashlib.md5(png_path.read_bytes()).hexdigest()
+                current_hash = _image_hash(png_path)
                 if current_hash == last_hash:
                     png_path.unlink(missing_ok=True)
                     print(

--- a/src/kindle_cap/orchestrator.py
+++ b/src/kindle_cap/orchestrator.py
@@ -1,15 +1,16 @@
 """Orchestrate the capture loop, dry-run, and PDF assembly."""
 
 import contextlib
+import dataclasses
 import hashlib
 from pathlib import Path
 from time import sleep
 
 from .capture import capture_rect
-from .config import CaptureConfig
+from .config import CaptureConfig, Direction
 from .keys import send_next_page
 from .pdf import build_pdf
-from .preflight import preflight
+from .preflight import detect_direction, preflight
 from .window import activate_kindle, get_window_geometry
 
 
@@ -17,6 +18,7 @@ def run(
     config: CaptureConfig,
     dry_run: bool = False,
     auto_stop: bool = False,
+    auto_direction: bool = False,
 ) -> None:
     preflight()
     config.out.mkdir(parents=True, exist_ok=True)
@@ -25,6 +27,38 @@ def run(
         _run_dry(config)
         return
 
+    if auto_direction:
+        out_dir = config.out / config.name
+        out_dir.mkdir(parents=True, exist_ok=True)
+        _purge_old_pages(out_dir)
+
+        resolved_direction, probe_pngs = detect_direction(
+            out_dir=out_dir,
+            geom_provider=get_window_geometry,
+            activator=activate_kindle,
+            capturer=capture_rect,
+            sender=send_next_page,
+            sleeper=sleep,
+            wait=config.wait,
+        )
+        resolved_config = dataclasses.replace(config, direction=resolved_direction)
+
+        if probe_pngs:
+            seed_hashes = [_image_hash(p) for p in probe_pngs]
+            _capture_book(
+                resolved_config,
+                auto_stop=auto_stop,
+                start_index=len(probe_pngs) + 1,
+                seed_hashes=seed_hashes,
+            )
+        else:
+            _capture_book(resolved_config, auto_stop=auto_stop)
+        return
+
+    if config.direction is None:
+        raise ValueError(
+            "direction を指定してください（または auto_direction=True を使用）"
+        )
     _capture_book(config, auto_stop=auto_stop)
 
 

--- a/src/kindle_cap/orchestrator.py
+++ b/src/kindle_cap/orchestrator.py
@@ -32,17 +32,41 @@ def _image_hash(path: Path) -> str:
     return hashlib.md5(path.read_bytes()).hexdigest()
 
 
-def _capture_book(config: CaptureConfig, *, auto_stop: bool) -> None:
-    """preflight 抜きの単一書籍撮影。direction は確定済みで呼ばれる前提。"""
+def _capture_book(
+    config: CaptureConfig,
+    *,
+    auto_stop: bool,
+    start_index: int = 1,
+    seed_hashes: list[str] | None = None,
+) -> None:
+    """preflight 抜きの単一書籍撮影。direction は確定済みで呼ばれる前提。
+
+    start_index > 1 の場合は試写流用モード:
+        - out_dir の page_001..start_index-1.png を既存ページとして captured に含める
+        - _purge_old_pages は呼ばない（試写を保護）
+        - 最初の反復は先に send_next_page を送る（試写ループ末尾は矢印未送信のため）
+    seed_hashes: auto_stop の last_hash 初期値として使うハッシュ列（試写ハッシュなど）。
+    """
     assert config.direction is not None, "_capture_book requires resolved direction"
     out_dir = config.out / config.name
     out_dir.mkdir(parents=True, exist_ok=True)
-    _purge_old_pages(out_dir)
+    if start_index == 1:
+        _purge_old_pages(out_dir)
 
     captured: list[Path] = []
-    last_hash: str | None = None
+    if start_index > 1:
+        for i in range(1, start_index):
+            captured.append(out_dir / f"page_{i:03d}.png")
+
+    last_hash: str | None = seed_hashes[-1] if seed_hashes else None
     try:
-        for i in range(1, config.pages + 1):
+        for i in range(start_index, config.pages + 1):
+            # 試写流用時の最初の反復は、試写ループ末尾で矢印を送っていないため
+            # 先にページを進めてから撮影する
+            if i == start_index and start_index > 1:
+                send_next_page(config.direction)
+                sleep(config.wait)
+
             print(f"[{i}/{config.pages}] capturing page", flush=True)
             activate_kindle()
             geom = get_window_geometry()

--- a/src/kindle_cap/orchestrator.py
+++ b/src/kindle_cap/orchestrator.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from time import sleep
 
 from .capture import capture_rect
-from .config import CaptureConfig, Direction
+from .config import CaptureConfig
 from .keys import send_next_page
 from .pdf import build_pdf
 from .preflight import detect_direction, preflight
@@ -56,9 +56,7 @@ def run(
         return
 
     if config.direction is None:
-        raise ValueError(
-            "direction を指定してください（または auto_direction=True を使用）"
-        )
+        raise ValueError("direction を指定してください（または auto_direction=True を使用）")
     _capture_book(config, auto_stop=auto_stop)
 
 

--- a/src/kindle_cap/orchestrator.py
+++ b/src/kindle_cap/orchestrator.py
@@ -33,7 +33,8 @@ def _image_hash(path: Path) -> str:
 
 
 def _capture_book(config: CaptureConfig, *, auto_stop: bool) -> None:
-    """preflight 抜きの単一書籍撮影。"""
+    """preflight 抜きの単一書籍撮影。direction は確定済みで呼ばれる前提。"""
+    assert config.direction is not None, "_capture_book requires resolved direction"
     out_dir = config.out / config.name
     out_dir.mkdir(parents=True, exist_ok=True)
     _purge_old_pages(out_dir)

--- a/src/kindle_cap/preflight.py
+++ b/src/kindle_cap/preflight.py
@@ -1,6 +1,11 @@
 """Validate prerequisites before starting the capture loop."""
 
+import hashlib
 import subprocess
+from collections.abc import Callable
+from pathlib import Path
+
+from .config import Direction, Geometry
 
 
 class PreflightError(RuntimeError):
@@ -65,3 +70,77 @@ def preflight() -> None:
             "システム設定 > プライバシーとセキュリティ > アクセシビリティ で\n"
             "ターミナル（iTerm2 等）に許可を与えてください。"
         )
+
+
+def _md5(path: Path) -> str:
+    return hashlib.md5(path.read_bytes()).hexdigest()
+
+
+def detect_direction(
+    *,
+    out_dir: Path,
+    geom_provider: Callable[[], Geometry],
+    activator: Callable[[], None],
+    capturer: Callable[[Geometry, Path], None],
+    sender: Callable[[Direction], None],
+    sleeper: Callable[[float], None],
+    wait: float,
+    probe_direction: Direction = Direction.RTL,
+    probe_count: int = 3,
+) -> tuple[Direction, list[Path]]:
+    """表紙起点で direction を判定する。
+
+    アルゴリズム:
+        1. 起点フレーム (_origin.png) を撮影
+        2. probe_direction を probe_count 回送って page_001..N.png に撮影
+        3. 起点と最終試写を MD5 比較:
+           - 変化あり → (probe_direction, 試写リスト) を返す（試写は本番採用）
+           - 変化なし → 試写を全削除し、逆方向で 1 回だけ verify
+              - verify で変化あり → (other_direction, []) を返す（本番は page_001 から）
+              - verify でも変化なし → PreflightError
+
+    試写は実 PNG として out_dir に書き出されるため、成功時はそのまま本番流用できる。
+    依存性注入: keys.send_next_page / capture_rect 等を Callable で受ける。
+    """
+    activator()
+    geom = geom_provider()
+    origin_path = out_dir / "_origin.png"
+    try:
+        capturer(geom, origin_path)
+        origin_hash = _md5(origin_path)
+
+        probe_pngs: list[Path] = []
+        for i in range(1, probe_count + 1):
+            sender(probe_direction)
+            sleeper(wait)
+            activator()
+            geom = geom_provider()
+            png = out_dir / f"page_{i:03d}.png"
+            capturer(geom, png)
+            probe_pngs.append(png)
+
+        if _md5(probe_pngs[-1]) != origin_hash:
+            return probe_direction, probe_pngs
+
+        # probe 無反応 → 試写を全削除して逆方向で確認
+        for p in probe_pngs:
+            p.unlink(missing_ok=True)
+        other = Direction.LTR if probe_direction is Direction.RTL else Direction.RTL
+        sender(other)
+        sleeper(wait)
+        activator()
+        geom = geom_provider()
+        verify_path = out_dir / "_verify.png"
+        try:
+            capturer(geom, verify_path)
+            if _md5(verify_path) != origin_hash:
+                return other, []
+        finally:
+            verify_path.unlink(missing_ok=True)
+
+        raise PreflightError(
+            "両方向ともページが進みません。"
+            "Kindle にフォーカスがないか、書籍が 1 ページしかない可能性があります。"
+        )
+    finally:
+        origin_path.unlink(missing_ok=True)

--- a/tests/integration/test_real_preflight.py
+++ b/tests/integration/test_real_preflight.py
@@ -1,13 +1,21 @@
 """preflight.py の live integration: 実 osascript で Kindle 状態を確認する。"""
 
+from pathlib import Path
+from time import sleep
+
 import pytest
 
+from kindle_cap.capture import capture_rect
+from kindle_cap.config import Direction
+from kindle_cap.keys import send_next_page
 from kindle_cap.preflight import (
     _can_send_keystrokes,
     _has_kindle_window,
     _is_kindle_running,
+    detect_direction,
     preflight,
 )
+from kindle_cap.window import activate_kindle, get_window_geometry
 
 
 @pytest.mark.live
@@ -30,3 +38,29 @@ def test_real_can_send_keystrokes_returns_true_when_authorized() -> None:
 @pytest.mark.live
 def test_real_preflight_passes_with_running_kindle() -> None:
     preflight()  # 例外が出ないこと
+
+
+@pytest.mark.live
+def test_real_detect_direction_returns_a_direction(tmp_path: Path) -> None:
+    """実機 Kindle で detect_direction を実行し、Direction が返ることを確認。
+
+    前提: Kindle.app 起動済み・書籍が表紙ページで開かれている。
+    本テストは実際にページを送るので、実行後は表紙から probe_count 枚進んだ
+    位置になっている可能性がある（手動で表紙に戻すこと）。
+    """
+    direction, pngs = detect_direction(
+        out_dir=tmp_path,
+        geom_provider=get_window_geometry,
+        activator=activate_kindle,
+        capturer=capture_rect,
+        sender=send_next_page,
+        sleeper=sleep,
+        wait=1.5,
+    )
+    assert direction in (Direction.RTL, Direction.LTR)
+    # 試写流用 (3 枚) または fallback (空) のいずれか
+    assert len(pngs) in (0, 3)
+    if pngs:
+        for p in pngs:
+            assert p.exists()
+            assert p.stat().st_size > 0

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -178,7 +178,8 @@ def test_rebuild_pdf_missing_dir_exits_nonzero(tmp_path: Path) -> None:
 
 @patch("kindle_cap.cli.orchestrator_run")
 def test_capture_auto_direction_routes_to_run_with_flag(
-    mock_run: MagicMock, tmp_path: Path,
+    mock_run: MagicMock,
+    tmp_path: Path,
 ) -> None:
     """--auto-direction 単体指定で auto_direction=True、direction は None"""
     app = _make_app(capture)
@@ -199,9 +200,15 @@ def test_capture_direction_and_auto_direction_conflict_exits_nonzero(
     result = runner.invoke(
         app,
         [
-            "--name", "x", "--pages", "5",
-            "--direction", "rtl", "--auto-direction",
-            "--out", str(tmp_path),
+            "--name",
+            "x",
+            "--pages",
+            "5",
+            "--direction",
+            "rtl",
+            "--auto-direction",
+            "--out",
+            str(tmp_path),
         ],
     )
     assert result.exit_code != 0
@@ -214,7 +221,8 @@ def test_capture_neither_direction_nor_auto_direction_exits_nonzero(
     """--direction も --auto-direction も未指定はエラー"""
     app = _make_app(capture)
     result = runner.invoke(
-        app, ["--name", "x", "--pages", "5", "--out", str(tmp_path)],
+        app,
+        ["--name", "x", "--pages", "5", "--out", str(tmp_path)],
     )
     assert result.exit_code != 0
     assert "いずれか" in result.output
@@ -222,7 +230,8 @@ def test_capture_neither_direction_nor_auto_direction_exits_nonzero(
 
 @patch("kindle_cap.cli.orchestrator_run")
 def test_capture_existing_direction_still_works(
-    mock_run: MagicMock, tmp_path: Path,
+    mock_run: MagicMock,
+    tmp_path: Path,
 ) -> None:
     """後方互換: --direction rtl 単体で従来通り動く"""
     app = _make_app(capture)
@@ -237,16 +246,22 @@ def test_capture_existing_direction_still_works(
 
 @patch("kindle_cap.cli.orchestrator_run")
 def test_capture_auto_direction_combined_with_auto_stop(
-    mock_run: MagicMock, tmp_path: Path,
+    mock_run: MagicMock,
+    tmp_path: Path,
 ) -> None:
     """--auto-direction と --auto-stop を組み合わせて指定できる"""
     app = _make_app(capture)
     result = runner.invoke(
         app,
         [
-            "--name", "x", "--pages", "100",
-            "--auto-direction", "--auto-stop",
-            "--out", str(tmp_path),
+            "--name",
+            "x",
+            "--pages",
+            "100",
+            "--auto-direction",
+            "--auto-stop",
+            "--out",
+            str(tmp_path),
         ],
     )
     assert result.exit_code == 0, result.output

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -5,6 +5,7 @@ import typer
 from typer.testing import CliRunner
 
 from kindle_cap.cli import capture, rebuild_pdf
+from kindle_cap.config import Direction
 
 runner = CliRunner()
 
@@ -168,3 +169,86 @@ def test_rebuild_pdf_missing_dir_exits_nonzero(tmp_path: Path) -> None:
     app = _make_app(rebuild_pdf)
     result = runner.invoke(app, [str(missing)])
     assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# --auto-direction フラグと排他バリデーション
+# ---------------------------------------------------------------------------
+
+
+@patch("kindle_cap.cli.orchestrator_run")
+def test_capture_auto_direction_routes_to_run_with_flag(
+    mock_run: MagicMock, tmp_path: Path,
+) -> None:
+    """--auto-direction 単体指定で auto_direction=True、direction は None"""
+    app = _make_app(capture)
+    result = runner.invoke(
+        app,
+        ["--name", "x", "--pages", "5", "--auto-direction", "--out", str(tmp_path)],
+    )
+    assert result.exit_code == 0, result.output
+    assert mock_run.call_args.kwargs.get("auto_direction") is True
+    assert mock_run.call_args.args[0].direction is None
+
+
+def test_capture_direction_and_auto_direction_conflict_exits_nonzero(
+    tmp_path: Path,
+) -> None:
+    """--direction と --auto-direction の同時指定はエラー"""
+    app = _make_app(capture)
+    result = runner.invoke(
+        app,
+        [
+            "--name", "x", "--pages", "5",
+            "--direction", "rtl", "--auto-direction",
+            "--out", str(tmp_path),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "同時指定" in result.output
+
+
+def test_capture_neither_direction_nor_auto_direction_exits_nonzero(
+    tmp_path: Path,
+) -> None:
+    """--direction も --auto-direction も未指定はエラー"""
+    app = _make_app(capture)
+    result = runner.invoke(
+        app, ["--name", "x", "--pages", "5", "--out", str(tmp_path)],
+    )
+    assert result.exit_code != 0
+    assert "いずれか" in result.output
+
+
+@patch("kindle_cap.cli.orchestrator_run")
+def test_capture_existing_direction_still_works(
+    mock_run: MagicMock, tmp_path: Path,
+) -> None:
+    """後方互換: --direction rtl 単体で従来通り動く"""
+    app = _make_app(capture)
+    result = runner.invoke(
+        app,
+        ["--name", "x", "--pages", "5", "--direction", "rtl", "--out", str(tmp_path)],
+    )
+    assert result.exit_code == 0, result.output
+    assert mock_run.call_args.args[0].direction is Direction.RTL
+    assert mock_run.call_args.kwargs.get("auto_direction") is False
+
+
+@patch("kindle_cap.cli.orchestrator_run")
+def test_capture_auto_direction_combined_with_auto_stop(
+    mock_run: MagicMock, tmp_path: Path,
+) -> None:
+    """--auto-direction と --auto-stop を組み合わせて指定できる"""
+    app = _make_app(capture)
+    result = runner.invoke(
+        app,
+        [
+            "--name", "x", "--pages", "100",
+            "--auto-direction", "--auto-stop",
+            "--out", str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert mock_run.call_args.kwargs.get("auto_direction") is True
+    assert mock_run.call_args.kwargs.get("auto_stop") is True

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -192,3 +192,9 @@ def test_config_equality_by_value() -> None:
     c1 = CaptureConfig(**_valid_config_kwargs())
     c2 = CaptureConfig(**_valid_config_kwargs())
     assert c1 == c2
+
+
+def test_config_direction_none_allowed() -> None:
+    """auto-direction 経路で direction が確定するまで None を保持できる。"""
+    c = CaptureConfig(**_valid_config_kwargs(direction=None))
+    assert c.direction is None

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from kindle_cap.config import CaptureConfig, Direction, Geometry
-from kindle_cap.orchestrator import run
+from kindle_cap.orchestrator import _image_hash, run
 
 _GEOM = Geometry(x=0, y=0, width=100, height=100)
 
@@ -369,3 +369,17 @@ def test_run_auto_stop_with_all_unique_pages_takes_full_count(
     mock_cap.side_effect = _all_unique
     run(_config(tmp_path, pages=5), auto_stop=True)
     assert mock_pdf.call_args[0][0].__len__() == 5
+
+
+def test_image_hash_returns_md5_hex(tmp_path: Path) -> None:
+    p = tmp_path / "f.bin"
+    p.write_bytes(b"hello")
+    assert _image_hash(p) == "5d41402abc4b2a76b9719d911017c592"
+
+
+def test_image_hash_changes_on_byte_change(tmp_path: Path) -> None:
+    p = tmp_path / "f.bin"
+    p.write_bytes(b"hello")
+    h1 = _image_hash(p)
+    p.write_bytes(b"hello!")
+    assert h1 != _image_hash(p)

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1,8 +1,11 @@
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from kindle_cap.config import CaptureConfig, Direction, Geometry
 from kindle_cap.orchestrator import _capture_book, _image_hash, run
+from kindle_cap.preflight import PreflightError
 
 _GEOM = Geometry(x=0, y=0, width=100, height=100)
 
@@ -506,3 +509,125 @@ def test_capture_book_default_start_index_unchanged_behavior(
     assert mock_cap.call_count == 3
     assert mock_send.call_count == 2  # 最終ページ後は送らない
     assert mock_pdf.call_args[0][0].__len__() == 3
+
+
+# ---------------------------------------------------------------------------
+# run() に auto_direction 統合
+# ---------------------------------------------------------------------------
+
+
+def _make_detect_stub(direction: Direction, num_pngs: int):
+    """detect_direction の挙動を模倣: out_dir に試写 PNG を書き出してから返す。"""
+
+    def _stub(*, out_dir, **_kwargs):
+        pngs = []
+        for i in range(1, num_pngs + 1):
+            p = out_dir / f"page_{i:03d}.png"
+            p.write_bytes(f"probe-{i}".encode())
+            pngs.append(p)
+        return (direction, pngs)
+
+    return _stub
+
+
+@patch("kindle_cap.orchestrator.build_pdf")
+@patch("kindle_cap.orchestrator.send_next_page")
+@patch("kindle_cap.orchestrator.capture_rect")
+@patch("kindle_cap.orchestrator.get_window_geometry")
+@patch("kindle_cap.orchestrator.activate_kindle")
+@patch("kindle_cap.orchestrator.preflight")
+@patch("kindle_cap.orchestrator.detect_direction")
+def test_run_auto_direction_resolves_direction_via_detect(
+    mock_detect, mock_pre, mock_act, mock_geom, mock_cap, mock_send, mock_pdf,
+    tmp_path: Path,
+) -> None:
+    """auto_direction=True で detect_direction が呼ばれ、確定した direction で本撮影"""
+    mock_geom.return_value = _GEOM
+    mock_detect.side_effect = _make_detect_stub(Direction.LTR, 3)
+    mock_cap.side_effect = lambda g, p: p.write_bytes(b"new")
+    config = _config(tmp_path, pages=5, direction=None)
+    run(config, auto_direction=True)
+    assert mock_detect.called
+    # send_next_page は LTR で呼ばれる（試写流用後の本番ループ送信のみ検査）
+    assert all(c.args[0] is Direction.LTR for c in mock_send.call_args_list)
+
+
+@patch("kindle_cap.orchestrator.build_pdf")
+@patch("kindle_cap.orchestrator.send_next_page")
+@patch("kindle_cap.orchestrator.capture_rect")
+@patch("kindle_cap.orchestrator.get_window_geometry")
+@patch("kindle_cap.orchestrator.activate_kindle")
+@patch("kindle_cap.orchestrator.preflight")
+@patch("kindle_cap.orchestrator.detect_direction")
+def test_run_auto_direction_reuses_probe_pngs_for_first_three_pages(
+    mock_detect, mock_pre, mock_act, mock_geom, mock_cap, mock_send, mock_pdf,
+    tmp_path: Path,
+) -> None:
+    """detect が 3 枚返したら、capture_rect は (pages - 3) 回しか呼ばれない"""
+    mock_geom.return_value = _GEOM
+    mock_detect.side_effect = _make_detect_stub(Direction.RTL, 3)
+    mock_cap.side_effect = lambda g, p: p.write_bytes(b"new")
+    config = _config(tmp_path, pages=5, direction=None)
+    run(config, auto_direction=True)
+    assert mock_cap.call_count == 2  # page_004 + page_005
+    # PDF には 5 枚（試写 3 + 新規 2）
+    assert mock_pdf.call_args[0][0].__len__() == 5
+
+
+@patch("kindle_cap.orchestrator.build_pdf")
+@patch("kindle_cap.orchestrator.send_next_page")
+@patch("kindle_cap.orchestrator.capture_rect")
+@patch("kindle_cap.orchestrator.get_window_geometry")
+@patch("kindle_cap.orchestrator.activate_kindle")
+@patch("kindle_cap.orchestrator.preflight")
+@patch("kindle_cap.orchestrator.detect_direction")
+def test_run_auto_direction_with_fallback_starts_at_page_001(
+    mock_detect, mock_pre, mock_act, mock_geom, mock_cap, mock_send, mock_pdf,
+    tmp_path: Path,
+) -> None:
+    """detect が空リストを返した場合、_capture_book は通常通り start_index=1 から"""
+    mock_geom.return_value = _GEOM
+    mock_detect.return_value = (Direction.LTR, [])
+    mock_cap.side_effect = lambda g, p: p.write_bytes(f"u-{p.name}".encode())
+    config = _config(tmp_path, pages=3, direction=None)
+    run(config, auto_direction=True)
+    assert mock_cap.call_count == 3
+    assert mock_pdf.call_args[0][0].__len__() == 3
+
+
+@patch("kindle_cap.orchestrator.preflight")
+@patch("kindle_cap.orchestrator.detect_direction")
+def test_run_auto_direction_propagates_preflight_error(
+    mock_detect, mock_pre, tmp_path: Path,
+) -> None:
+    """detect_direction が PreflightError を上げたら run も伝播"""
+    mock_detect.side_effect = PreflightError("両方向ともページが進みません")
+    config = _config(tmp_path, pages=5, direction=None)
+    with pytest.raises(PreflightError):
+        run(config, auto_direction=True)
+
+
+@patch("kindle_cap.orchestrator.preflight")
+def test_run_with_direction_none_and_auto_direction_false_raises(
+    mock_pre, tmp_path: Path,
+) -> None:
+    """direction=None かつ auto_direction=False は ValueError"""
+    config = _config(tmp_path, pages=5, direction=None)
+    with pytest.raises(ValueError, match="direction"):
+        run(config, auto_direction=False)
+
+
+@patch("kindle_cap.orchestrator.capture_rect")
+@patch("kindle_cap.orchestrator.get_window_geometry")
+@patch("kindle_cap.orchestrator.activate_kindle")
+@patch("kindle_cap.orchestrator.preflight")
+@patch("kindle_cap.orchestrator.detect_direction")
+def test_run_dry_run_with_auto_direction_skips_detect(
+    mock_detect, mock_pre, mock_act, mock_geom, mock_cap, tmp_path: Path,
+) -> None:
+    """dry_run=True のとき auto_direction を渡しても detect_direction は呼ばれない"""
+    mock_geom.return_value = _GEOM
+    config = _config(tmp_path, pages=1, direction=None)
+    run(config, dry_run=True, auto_direction=True)
+    assert not mock_detect.called
+    assert mock_cap.call_count == 1  # _run_dry の 1 枚撮影のみ

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from kindle_cap.config import CaptureConfig, Direction, Geometry
-from kindle_cap.orchestrator import _image_hash, run
+from kindle_cap.orchestrator import _capture_book, _image_hash, run
 
 _GEOM = Geometry(x=0, y=0, width=100, height=100)
 
@@ -383,3 +383,126 @@ def test_image_hash_changes_on_byte_change(tmp_path: Path) -> None:
     h1 = _image_hash(p)
     p.write_bytes(b"hello!")
     assert h1 != _image_hash(p)
+
+
+# ---------------------------------------------------------------------------
+# _capture_book: start_index / seed_hashes 拡張
+# ---------------------------------------------------------------------------
+
+
+@patch("kindle_cap.orchestrator.build_pdf")
+@patch("kindle_cap.orchestrator.send_next_page")
+@patch("kindle_cap.orchestrator.capture_rect")
+@patch("kindle_cap.orchestrator.get_window_geometry")
+@patch("kindle_cap.orchestrator.activate_kindle")
+def test_capture_book_with_start_index_skips_purge_and_resumes(
+    mock_act, mock_geom, mock_cap, mock_send, mock_pdf, tmp_path: Path,
+) -> None:
+    """start_index=4 のとき page_001..003 は採用されたまま、page_004 から撮影。
+    最初のループ反復で先に send_next_page を呼ぶ。"""
+    mock_geom.return_value = _GEOM
+    out_dir = tmp_path / "bk"
+    out_dir.mkdir()
+    for i in range(1, 4):
+        (out_dir / f"page_{i:03d}.png").write_bytes(b"existing")
+    mock_cap.side_effect = lambda g, p: p.write_bytes(b"new")
+    _capture_book(_config(tmp_path, pages=5), auto_stop=False, start_index=4)
+    # 撮影は page_004, page_005 の 2 回
+    assert mock_cap.call_count == 2
+    # send_next_page: page_004 撮る前 + page_004 → page_005 移動 = 2 回
+    assert mock_send.call_count == 2
+    # PDF には 5 枚渡される（試写 3 + 新規 2）
+    assert mock_pdf.call_args[0][0].__len__() == 5
+
+
+@patch("kindle_cap.orchestrator.build_pdf")
+@patch("kindle_cap.orchestrator.send_next_page")
+@patch("kindle_cap.orchestrator.capture_rect")
+@patch("kindle_cap.orchestrator.get_window_geometry")
+@patch("kindle_cap.orchestrator.activate_kindle")
+def test_capture_book_with_start_index_one_purges_old_pages(
+    mock_act, mock_geom, mock_cap, mock_send, mock_pdf, tmp_path: Path,
+) -> None:
+    """通常の start_index=1 では既存 page_*.png を purge する（既存挙動）。"""
+    mock_geom.return_value = _GEOM
+    out_dir = tmp_path / "bk"
+    out_dir.mkdir()
+    stale = out_dir / "page_001.png"
+    stale.write_bytes(b"stale")
+    mock_cap.side_effect = lambda g, p: p.write_bytes(b"new")
+    _capture_book(_config(tmp_path, pages=2), auto_stop=False, start_index=1)
+    # purge されて mock_cap で書き直されている
+    assert stale.read_bytes() == b"new"
+
+
+@patch("kindle_cap.orchestrator.build_pdf")
+@patch("kindle_cap.orchestrator.send_next_page")
+@patch("kindle_cap.orchestrator.capture_rect")
+@patch("kindle_cap.orchestrator.get_window_geometry")
+@patch("kindle_cap.orchestrator.activate_kindle")
+def test_capture_book_with_seed_hashes_stops_immediately_when_first_page_matches(
+    mock_act, mock_geom, mock_cap, mock_send, mock_pdf, tmp_path: Path,
+) -> None:
+    """seed_hashes の最後と本番初回ページのハッシュが一致すれば auto_stop が即停止。"""
+    mock_geom.return_value = _GEOM
+    out_dir = tmp_path / "bk"
+    out_dir.mkdir()
+    for i in range(1, 4):
+        (out_dir / f"page_{i:03d}.png").write_bytes(f"page-{i}".encode())
+    last_seed_hash = _image_hash(out_dir / "page_003.png")
+    # page_004 を撮るとき page_003 と同一バイトを書く → 即停止
+    mock_cap.side_effect = lambda g, p: p.write_bytes(b"page-3")
+    _capture_book(
+        _config(tmp_path, pages=10),
+        auto_stop=True,
+        start_index=4,
+        seed_hashes=[
+            _image_hash(out_dir / "page_001.png"),
+            _image_hash(out_dir / "page_002.png"),
+            last_seed_hash,
+        ],
+    )
+    # page_004.png は重複検出で削除される
+    assert not (out_dir / "page_004.png").exists()
+    # PDF には試写 3 枚のみ
+    assert mock_pdf.call_args[0][0].__len__() == 3
+
+
+@patch("kindle_cap.orchestrator.build_pdf")
+@patch("kindle_cap.orchestrator.send_next_page")
+@patch("kindle_cap.orchestrator.capture_rect")
+@patch("kindle_cap.orchestrator.get_window_geometry")
+@patch("kindle_cap.orchestrator.activate_kindle")
+def test_capture_book_passes_existing_pages_to_pdf_when_start_index_gt_one(
+    mock_act, mock_geom, mock_cap, mock_send, mock_pdf, tmp_path: Path,
+) -> None:
+    """page_001..start_index-1.png が PDF 入力に含まれる。"""
+    mock_geom.return_value = _GEOM
+    out_dir = tmp_path / "bk"
+    out_dir.mkdir()
+    for i in range(1, 4):
+        (out_dir / f"page_{i:03d}.png").write_bytes(f"existing-{i}".encode())
+    mock_cap.side_effect = lambda g, p: p.write_bytes(b"new")
+    _capture_book(_config(tmp_path, pages=5), auto_stop=False, start_index=4)
+    pdf_inputs = mock_pdf.call_args[0][0]
+    assert [p.name for p in pdf_inputs] == [
+        "page_001.png", "page_002.png", "page_003.png",
+        "page_004.png", "page_005.png",
+    ]
+
+
+@patch("kindle_cap.orchestrator.build_pdf")
+@patch("kindle_cap.orchestrator.send_next_page")
+@patch("kindle_cap.orchestrator.capture_rect")
+@patch("kindle_cap.orchestrator.get_window_geometry")
+@patch("kindle_cap.orchestrator.activate_kindle")
+def test_capture_book_default_start_index_unchanged_behavior(
+    mock_act, mock_geom, mock_cap, mock_send, mock_pdf, tmp_path: Path,
+) -> None:
+    """start_index 引数を渡さない既存呼び出しは挙動不変（page_001 から N 枚撮る）。"""
+    mock_geom.return_value = _GEOM
+    mock_cap.side_effect = lambda g, p: p.write_bytes(f"u-{p.name}".encode())
+    _capture_book(_config(tmp_path, pages=3), auto_stop=False)
+    assert mock_cap.call_count == 3
+    assert mock_send.call_count == 2  # 最終ページ後は送らない
+    assert mock_pdf.call_args[0][0].__len__() == 3

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -399,7 +399,12 @@ def test_image_hash_changes_on_byte_change(tmp_path: Path) -> None:
 @patch("kindle_cap.orchestrator.get_window_geometry")
 @patch("kindle_cap.orchestrator.activate_kindle")
 def test_capture_book_with_start_index_skips_purge_and_resumes(
-    mock_act, mock_geom, mock_cap, mock_send, mock_pdf, tmp_path: Path,
+    mock_act,
+    mock_geom,
+    mock_cap,
+    mock_send,
+    mock_pdf,
+    tmp_path: Path,
 ) -> None:
     """start_index=4 のとき page_001..003 は採用されたまま、page_004 から撮影。
     最初のループ反復で先に send_next_page を呼ぶ。"""
@@ -424,7 +429,12 @@ def test_capture_book_with_start_index_skips_purge_and_resumes(
 @patch("kindle_cap.orchestrator.get_window_geometry")
 @patch("kindle_cap.orchestrator.activate_kindle")
 def test_capture_book_with_start_index_one_purges_old_pages(
-    mock_act, mock_geom, mock_cap, mock_send, mock_pdf, tmp_path: Path,
+    mock_act,
+    mock_geom,
+    mock_cap,
+    mock_send,
+    mock_pdf,
+    tmp_path: Path,
 ) -> None:
     """通常の start_index=1 では既存 page_*.png を purge する（既存挙動）。"""
     mock_geom.return_value = _GEOM
@@ -444,7 +454,12 @@ def test_capture_book_with_start_index_one_purges_old_pages(
 @patch("kindle_cap.orchestrator.get_window_geometry")
 @patch("kindle_cap.orchestrator.activate_kindle")
 def test_capture_book_with_seed_hashes_stops_immediately_when_first_page_matches(
-    mock_act, mock_geom, mock_cap, mock_send, mock_pdf, tmp_path: Path,
+    mock_act,
+    mock_geom,
+    mock_cap,
+    mock_send,
+    mock_pdf,
+    tmp_path: Path,
 ) -> None:
     """seed_hashes の最後と本番初回ページのハッシュが一致すれば auto_stop が即停止。"""
     mock_geom.return_value = _GEOM
@@ -477,7 +492,12 @@ def test_capture_book_with_seed_hashes_stops_immediately_when_first_page_matches
 @patch("kindle_cap.orchestrator.get_window_geometry")
 @patch("kindle_cap.orchestrator.activate_kindle")
 def test_capture_book_passes_existing_pages_to_pdf_when_start_index_gt_one(
-    mock_act, mock_geom, mock_cap, mock_send, mock_pdf, tmp_path: Path,
+    mock_act,
+    mock_geom,
+    mock_cap,
+    mock_send,
+    mock_pdf,
+    tmp_path: Path,
 ) -> None:
     """page_001..start_index-1.png が PDF 入力に含まれる。"""
     mock_geom.return_value = _GEOM
@@ -489,8 +509,11 @@ def test_capture_book_passes_existing_pages_to_pdf_when_start_index_gt_one(
     _capture_book(_config(tmp_path, pages=5), auto_stop=False, start_index=4)
     pdf_inputs = mock_pdf.call_args[0][0]
     assert [p.name for p in pdf_inputs] == [
-        "page_001.png", "page_002.png", "page_003.png",
-        "page_004.png", "page_005.png",
+        "page_001.png",
+        "page_002.png",
+        "page_003.png",
+        "page_004.png",
+        "page_005.png",
     ]
 
 
@@ -500,7 +523,12 @@ def test_capture_book_passes_existing_pages_to_pdf_when_start_index_gt_one(
 @patch("kindle_cap.orchestrator.get_window_geometry")
 @patch("kindle_cap.orchestrator.activate_kindle")
 def test_capture_book_default_start_index_unchanged_behavior(
-    mock_act, mock_geom, mock_cap, mock_send, mock_pdf, tmp_path: Path,
+    mock_act,
+    mock_geom,
+    mock_cap,
+    mock_send,
+    mock_pdf,
+    tmp_path: Path,
 ) -> None:
     """start_index 引数を渡さない既存呼び出しは挙動不変（page_001 から N 枚撮る）。"""
     mock_geom.return_value = _GEOM
@@ -538,7 +566,13 @@ def _make_detect_stub(direction: Direction, num_pngs: int):
 @patch("kindle_cap.orchestrator.preflight")
 @patch("kindle_cap.orchestrator.detect_direction")
 def test_run_auto_direction_resolves_direction_via_detect(
-    mock_detect, mock_pre, mock_act, mock_geom, mock_cap, mock_send, mock_pdf,
+    mock_detect,
+    mock_pre,
+    mock_act,
+    mock_geom,
+    mock_cap,
+    mock_send,
+    mock_pdf,
     tmp_path: Path,
 ) -> None:
     """auto_direction=True で detect_direction が呼ばれ、確定した direction で本撮影"""
@@ -560,7 +594,13 @@ def test_run_auto_direction_resolves_direction_via_detect(
 @patch("kindle_cap.orchestrator.preflight")
 @patch("kindle_cap.orchestrator.detect_direction")
 def test_run_auto_direction_reuses_probe_pngs_for_first_three_pages(
-    mock_detect, mock_pre, mock_act, mock_geom, mock_cap, mock_send, mock_pdf,
+    mock_detect,
+    mock_pre,
+    mock_act,
+    mock_geom,
+    mock_cap,
+    mock_send,
+    mock_pdf,
     tmp_path: Path,
 ) -> None:
     """detect が 3 枚返したら、capture_rect は (pages - 3) 回しか呼ばれない"""
@@ -582,7 +622,13 @@ def test_run_auto_direction_reuses_probe_pngs_for_first_three_pages(
 @patch("kindle_cap.orchestrator.preflight")
 @patch("kindle_cap.orchestrator.detect_direction")
 def test_run_auto_direction_with_fallback_starts_at_page_001(
-    mock_detect, mock_pre, mock_act, mock_geom, mock_cap, mock_send, mock_pdf,
+    mock_detect,
+    mock_pre,
+    mock_act,
+    mock_geom,
+    mock_cap,
+    mock_send,
+    mock_pdf,
     tmp_path: Path,
 ) -> None:
     """detect が空リストを返した場合、_capture_book は通常通り start_index=1 から"""
@@ -598,7 +644,9 @@ def test_run_auto_direction_with_fallback_starts_at_page_001(
 @patch("kindle_cap.orchestrator.preflight")
 @patch("kindle_cap.orchestrator.detect_direction")
 def test_run_auto_direction_propagates_preflight_error(
-    mock_detect, mock_pre, tmp_path: Path,
+    mock_detect,
+    mock_pre,
+    tmp_path: Path,
 ) -> None:
     """detect_direction が PreflightError を上げたら run も伝播"""
     mock_detect.side_effect = PreflightError("両方向ともページが進みません")
@@ -609,7 +657,8 @@ def test_run_auto_direction_propagates_preflight_error(
 
 @patch("kindle_cap.orchestrator.preflight")
 def test_run_with_direction_none_and_auto_direction_false_raises(
-    mock_pre, tmp_path: Path,
+    mock_pre,
+    tmp_path: Path,
 ) -> None:
     """direction=None かつ auto_direction=False は ValueError"""
     config = _config(tmp_path, pages=5, direction=None)
@@ -623,7 +672,12 @@ def test_run_with_direction_none_and_auto_direction_false_raises(
 @patch("kindle_cap.orchestrator.preflight")
 @patch("kindle_cap.orchestrator.detect_direction")
 def test_run_dry_run_with_auto_direction_skips_detect(
-    mock_detect, mock_pre, mock_act, mock_geom, mock_cap, tmp_path: Path,
+    mock_detect,
+    mock_pre,
+    mock_act,
+    mock_geom,
+    mock_cap,
+    tmp_path: Path,
 ) -> None:
     """dry_run=True のとき auto_direction を渡しても detect_direction は呼ばれない"""
     mock_geom.return_value = _GEOM

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -289,7 +289,7 @@ def test_detect_direction_error_message_mentions_focus_or_one_page(
 ) -> None:
     """エラーメッセージは原因を示唆する文言を含む"""
     cap = _capturer_writing_seq([b"x", b"x", b"x", b"x", b"x"])
-    with pytest.raises(PreflightError, match="フォーカス|1 ページ"):
+    with pytest.raises(PreflightError, match=r"フォーカス|1 ページ"):
         detect_direction(**_detect_kwargs(tmp_path, capturer=cap))
 
 

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -1,12 +1,16 @@
 import subprocess
+from collections.abc import Callable
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from kindle_cap.config import Direction, Geometry
 from kindle_cap.preflight import (
     PreflightError,
     _is_accessibility_error,
     _parse_count,
+    detect_direction,
     preflight,
 )
 
@@ -158,3 +162,114 @@ def test_preflight_short_circuits_on_kindle_missing(mock_run: MagicMock) -> None
     with pytest.raises(PreflightError):
         preflight()
     assert mock_run.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# detect_direction: 表紙起点での方向自動判定
+# capturer は呼び出し順に異なるバイト列を path に書き出す stub を渡す
+# 順序は (origin) → (probe1, probe2, probe3) → (verify) の最大 5 回
+# ---------------------------------------------------------------------------
+
+
+def _capturer_writing_seq(seq: list[bytes]) -> Callable[[Geometry, Path], None]:
+    """呼び出し順に seq[i] を path に書き込む stub。"""
+    counter = {"n": 0}
+
+    def _cap(geom: Geometry, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(seq[counter["n"]])
+        counter["n"] += 1
+
+    return _cap
+
+
+def _detect_kwargs(tmp_path: Path, **overrides):
+    base = dict(
+        out_dir=tmp_path,
+        geom_provider=lambda: Geometry(0, 0, 100, 100),
+        activator=lambda: None,
+        sender=MagicMock(),
+        sleeper=lambda _s: None,
+        wait=0.0,
+    )
+    base.update(overrides)
+    return base
+
+
+def test_detect_direction_returns_probe_direction_when_pages_advance(
+    tmp_path: Path,
+) -> None:
+    """起点 != 試写3 のシーケンス → probe_direction (RTL) を返し、試写を本番採用"""
+    cap = _capturer_writing_seq([b"origin", b"p1", b"p2", b"p3"])
+    direction, pngs = detect_direction(**_detect_kwargs(tmp_path, capturer=cap))
+    assert direction is Direction.RTL
+    assert [p.name for p in pngs] == ["page_001.png", "page_002.png", "page_003.png"]
+    assert all(p.exists() for p in pngs)
+
+
+def test_detect_direction_returns_probe_pngs_named_page_001_to_003(
+    tmp_path: Path,
+) -> None:
+    cap = _capturer_writing_seq([b"o", b"a", b"b", b"c"])
+    _, pngs = detect_direction(**_detect_kwargs(tmp_path, capturer=cap))
+    assert pngs[0] == tmp_path / "page_001.png"
+    assert pngs[1] == tmp_path / "page_002.png"
+    assert pngs[2] == tmp_path / "page_003.png"
+
+
+def test_detect_direction_unlinks_origin_png_on_success(tmp_path: Path) -> None:
+    cap = _capturer_writing_seq([b"o", b"a", b"b", b"c"])
+    detect_direction(**_detect_kwargs(tmp_path, capturer=cap))
+    assert not (tmp_path / "_origin.png").exists()
+
+
+def test_detect_direction_calls_sender_three_times_for_probe(tmp_path: Path) -> None:
+    cap = _capturer_writing_seq([b"o", b"a", b"b", b"c"])
+    sender = MagicMock()
+    detect_direction(**_detect_kwargs(tmp_path, capturer=cap, sender=sender))
+    assert sender.call_count == 3
+    assert all(c.args[0] is Direction.RTL for c in sender.call_args_list)
+
+
+def test_detect_direction_default_probe_direction_is_rtl(tmp_path: Path) -> None:
+    cap = _capturer_writing_seq([b"o", b"a", b"b", b"c"])
+    direction, _ = detect_direction(**_detect_kwargs(tmp_path, capturer=cap))
+    assert direction is Direction.RTL
+
+
+def test_detect_direction_uses_probe_count_parameter(tmp_path: Path) -> None:
+    """probe_count=5 を渡せば 5 枚撮る。"""
+    cap = _capturer_writing_seq([b"o", b"1", b"2", b"3", b"4", b"5"])
+    sender = MagicMock()
+    direction, pngs = detect_direction(
+        **_detect_kwargs(tmp_path, capturer=cap, sender=sender),
+        probe_count=5,
+    )
+    assert direction is Direction.RTL
+    assert len(pngs) == 5
+    assert sender.call_count == 5
+
+
+def test_detect_direction_falls_back_to_other_direction_when_no_advance(
+    tmp_path: Path,
+) -> None:
+    """起点 == 試写3（無反応）、verify では変化あり → other_direction を返し試写は破棄。"""
+    cap = _capturer_writing_seq([b"same", b"same", b"same", b"same", b"changed"])
+    sender = MagicMock()
+    direction, pngs = detect_direction(
+        **_detect_kwargs(tmp_path, capturer=cap, sender=sender),
+    )
+    assert direction is Direction.LTR
+    assert pngs == []
+    assert sender.call_args_list[-1].args[0] is Direction.LTR
+
+
+def test_detect_direction_unlinks_probe_pngs_on_fallback(tmp_path: Path) -> None:
+    """fallback 時、試写 PNG / _origin / _verify がすべて削除される。"""
+    cap = _capturer_writing_seq([b"same", b"same", b"same", b"same", b"changed"])
+    detect_direction(**_detect_kwargs(tmp_path, capturer=cap))
+    assert not (tmp_path / "page_001.png").exists()
+    assert not (tmp_path / "page_002.png").exists()
+    assert not (tmp_path / "page_003.png").exists()
+    assert not (tmp_path / "_origin.png").exists()
+    assert not (tmp_path / "_verify.png").exists()

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -273,3 +273,29 @@ def test_detect_direction_unlinks_probe_pngs_on_fallback(tmp_path: Path) -> None
     assert not (tmp_path / "page_003.png").exists()
     assert not (tmp_path / "_origin.png").exists()
     assert not (tmp_path / "_verify.png").exists()
+
+
+def test_detect_direction_raises_preflight_error_when_both_directions_unresponsive(
+    tmp_path: Path,
+) -> None:
+    """両方向とも無反応 → PreflightError"""
+    cap = _capturer_writing_seq([b"x", b"x", b"x", b"x", b"x"])
+    with pytest.raises(PreflightError):
+        detect_direction(**_detect_kwargs(tmp_path, capturer=cap))
+
+
+def test_detect_direction_error_message_mentions_focus_or_one_page(
+    tmp_path: Path,
+) -> None:
+    """エラーメッセージは原因を示唆する文言を含む"""
+    cap = _capturer_writing_seq([b"x", b"x", b"x", b"x", b"x"])
+    with pytest.raises(PreflightError, match="フォーカス|1 ページ"):
+        detect_direction(**_detect_kwargs(tmp_path, capturer=cap))
+
+
+def test_detect_direction_error_path_leaves_no_files(tmp_path: Path) -> None:
+    """エラー時も out_dir に余計なファイルを残さない"""
+    cap = _capturer_writing_seq([b"x", b"x", b"x", b"x", b"x"])
+    with pytest.raises(PreflightError):
+        detect_direction(**_detect_kwargs(tmp_path, capturer=cap))
+    assert list(tmp_path.glob("*.png")) == []


### PR DESCRIPTION
## Summary
- `preflight.detect_direction()` を依存性注入の純粋関数として新設。表紙起点で probe_direction を 3 回送って起点と最終フレームを MD5 比較し、変化あれば確定（試写を本番採用）/ 無ければ逆方向で 1 回 verify / 両方向無反応なら `PreflightError`
- `CaptureConfig.direction` を `Direction | None` に緩和、`orchestrator.run()` に `auto_direction` フラグを統合（試写流用は `start_index` / `seed_hashes` 経由で `_capture_book` に伝達）
- CLI 層で `--direction` / `--auto-direction` の排他バリデーション、後方互換維持

## Test plan
- [x] 184 unit tests pass (既存 154 + 新規 30)
- [x] mypy strict pass (9 source files)
- [x] pre-commit 全 hook pass (ruff check / format / mypy 含む)
- [x] @live integration: `tests/integration/test_real_preflight.py::test_real_detect_direction_returns_a_direction`
- [x] 実機検証: 試写流用パス（probe 成功 + `start_index=4` で続行、page_001-003 を本番採用、新規撮影は page_004-005 のみ）が正常動作
- [ ] 実機検証: 多様な書籍ジャンル (縦書き和書 / 横書き和書 / 洋書) での精度評価 — 一部書籍構造で誤判定の余地あり、精度改善（verify 複数回送信、画像差分比較等）は別 issue で追える

## ドキュメント
- README: 使用例 / オプション表 / 注意書きを更新（`--auto-direction` 推奨）
- CHANGELOG: `[Unreleased]` に Added エントリ追加

Closes #15