### PR TITLE
fix(capture): detect screencapture silent write failures

### DIFF
--- a/src/kindle_cap/capture.py
+++ b/src/kindle_cap/capture.py
@@ -8,6 +8,10 @@ from PIL import Image
 from .config import Geometry
 
 
+class CaptureError(RuntimeError):
+    pass
+
+
 def _build_screencapture_args(geom: Geometry, out_path: Path) -> list[str]:
     rect = f"{geom.x},{geom.y},{geom.width},{geom.height}"
     return ["screencapture", "-R", rect, "-x", str(out_path)]
@@ -26,8 +30,15 @@ def _flatten_alpha(path: Path) -> None:
 
 
 def capture_rect(geom: Geometry, out_path: Path) -> None:
-    subprocess.run(
+    # macOS の screencapture は書き込み失敗時でも exit 0 で抜けることがあるため、
+    # check=True に頼らず out_path の存在を確認する。stderr は診断のため捕捉する。
+    result = subprocess.run(
         _build_screencapture_args(geom, out_path),
         check=True,
+        capture_output=True,
+        text=True,
     )
+    if not out_path.exists():
+        stderr_text = (result.stderr or "").strip() or "(no stderr)"
+        raise CaptureError(f"screencapture exited 0 but did not create {out_path}: {stderr_text}")
     _flatten_alpha(out_path)

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -5,6 +6,7 @@ import pytest
 from PIL import Image
 
 from kindle_cap.capture import (
+    CaptureError,
     _build_screencapture_args,
     _flatten_alpha,
     capture_rect,
@@ -187,3 +189,50 @@ def test_capture_rect_uses_check_true(mock_run: MagicMock, tmp_path: Path) -> No
     mock_run.side_effect = _stub_screencapture_factory(out)
     capture_rect(Geometry(0, 0, 10, 10), out)
     assert mock_run.call_args.kwargs.get("check") is True
+
+
+# ---------------------------------------------------------------------------
+# 防御層: macOS の screencapture は書き込み失敗時でも exit 0 で抜けることがある。
+# check=True だけでは検知できないので out_path の存在を確認し、無ければ
+# CaptureError を上げて呼び出し元に意味のあるエラーを返す。
+# ---------------------------------------------------------------------------
+
+
+@patch("kindle_cap.capture.subprocess.run")
+def test_capture_rect_raises_capture_error_when_file_not_created(
+    mock_run: MagicMock,
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "missing.png"
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="", stderr="screencapture: cannot write file"
+    )
+    with pytest.raises(CaptureError):
+        capture_rect(Geometry(0, 0, 10, 10), out)
+
+
+@patch("kindle_cap.capture.subprocess.run")
+def test_capture_rect_error_includes_stderr_text(
+    mock_run: MagicMock,
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "missing.png"
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout="",
+        stderr="cannot write file to intended destination",
+    )
+    with pytest.raises(CaptureError, match="cannot write file to intended destination"):
+        capture_rect(Geometry(0, 0, 10, 10), out)
+
+
+@patch("kindle_cap.capture.subprocess.run")
+def test_capture_rect_error_includes_out_path(
+    mock_run: MagicMock,
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "page_153.png"
+    mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+    with pytest.raises(CaptureError, match=r"page_153\.png"):
+        capture_rect(Geometry(0, 0, 10, 10), out)


### PR DESCRIPTION
## Summary
macOS の `screencapture` が書き込み失敗時でも exit 0 で抜ける挙動に対する防御層。

## Background
600 ページキャプチャ中、ディスク逼迫 (残 4.4 GB) で page_153 の screencapture が
silent fail し、後段の Pillow が `FileNotFoundError` を上げてセッション全体が落ちた。
原因: `subprocess.run(check=True)` は終了コードしか見ないため、screencapture が
エラー文言を吐きつつ exit 0 で抜けたのを検知できない。

## Changes
- `CaptureError(RuntimeError)` 新設
- `capture_rect` で `capture_output=True` にして stderr を捕捉
- subprocess 後に `out_path.exists()` で実体確認、無ければ stderr を含む `CaptureError` を raise

## Test plan
- [x] ユニットテスト 3 本追加 (silent failure / stderr 含有 / out_path 含有)
- [x] `uv run pytest` 全 187 pass
- [x] `uv run ruff check src/ tests/` 全 pass
- [x] `uv run ruff format --check` 全 pass
- [x] `uv run mypy src/kindle_cap/` 全 pass
- [ ] CI 緑確認