### PR TITLE
fix(pdf): build_pdf がディスク容量不足を捕捉せず生 traceback が露出する (closes #19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 - `--auto-direction`：表紙起点で試写し、ページ綴じ方向（rtl/ltr）を自動判定。試写 3 枚は本番に流用するため重複撮影しない（issue #15）
 - 開発者向けドキュメント（`CHANGELOG.md`、`CONTRIBUTING.md`）
 - GitHub の Issue / Pull Request テンプレート（`.github/`）
+- `kindle_cap.pdf.PdfBuildError` 例外：`build_pdf` がディスク容量不足など予測可能な要因で失敗したことを表す
+
+### Fixed
+
+- ディスク容量不足 (`ENOSPC`) で PDF 生成が失敗したときに生 traceback を露出していたのを改修。`PdfBuildError` を raise し、CLI で日本語の説明的メッセージ + exit 1 で終了する。部分書き込みされた PDF は削除し、PNG は保持して `kindle-cap-pdf` で再生成可能 (issue #19)
 
 ## [0.1.0] - 2026-04-25
 

--- a/src/kindle_cap/cli.py
+++ b/src/kindle_cap/cli.py
@@ -6,7 +6,7 @@ import typer
 
 from .config import CaptureConfig, Direction
 from .orchestrator import run as orchestrator_run
-from .pdf import build_pdf
+from .pdf import PdfBuildError, build_pdf
 from .preflight import PreflightError
 
 
@@ -79,6 +79,9 @@ def capture(
     except PreflightError as e:
         typer.echo(f"[エラー] {e}", err=True)
         raise typer.Exit(code=1) from e
+    except PdfBuildError as e:
+        typer.echo(f"[エラー] {e}", err=True)
+        raise typer.Exit(code=1) from e
 
 
 def rebuild_pdf(
@@ -96,7 +99,11 @@ def rebuild_pdf(
         typer.echo(f"[エラー] {directory} に page_*.png が見つかりません", err=True)
         raise typer.Exit(code=1)
     out_path = directory.parent / f"{directory.name}.pdf"
-    build_pdf(pngs, out_path)
+    try:
+        build_pdf(pngs, out_path)
+    except PdfBuildError as e:
+        typer.echo(f"[エラー] {e}", err=True)
+        raise typer.Exit(code=1) from e
     typer.echo(f"PDF を作成しました: {out_path}")
 
 

--- a/src/kindle_cap/pdf.py
+++ b/src/kindle_cap/pdf.py
@@ -1,8 +1,13 @@
 """Combine PNG images into a single PDF using img2pdf (lossless)."""
 
+import errno
 from pathlib import Path
 
 import img2pdf
+
+
+class PdfBuildError(Exception):
+    """build_pdf がディスク容量不足など予測可能な要因で失敗したことを表す."""
 
 
 def build_pdf(png_paths: list[Path], out_path: Path) -> None:
@@ -12,5 +17,17 @@ def build_pdf(png_paths: list[Path], out_path: Path) -> None:
     # outputstream を渡すことで、PDF 全体を一度メモリに展開せずに直接ファイルへ
     # 書き出せる。1000+ ページのリフロー型書籍など長尺キャプチャに対応するため
     # ストリーム出力を採用。
-    with open(out_path, "wb") as fp:
-        img2pdf.convert([str(p) for p in png_paths], outputstream=fp)
+    try:
+        with open(out_path, "wb") as fp:
+            img2pdf.convert([str(p) for p in png_paths], outputstream=fp)
+    except OSError as e:
+        # 中途半端に書かれた PDF は再生成のじゃまになるので削除
+        out_path.unlink(missing_ok=True)
+        if e.errno == errno.ENOSPC:
+            png_dir = png_paths[0].parent
+            raise PdfBuildError(
+                f"ディスク容量不足で PDF を作成できませんでした。"
+                f"PNG は {png_dir} に残っているので、容量を確保後に "
+                f"`kindle-cap-pdf {png_dir}` で再生成可能です。"
+            ) from e
+        raise

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -6,6 +6,7 @@ from typer.testing import CliRunner
 
 from kindle_cap.cli import capture, rebuild_pdf
 from kindle_cap.config import Direction
+from kindle_cap.pdf import PdfBuildError
 
 runner = CliRunner()
 
@@ -169,6 +170,43 @@ def test_rebuild_pdf_missing_dir_exits_nonzero(tmp_path: Path) -> None:
     app = _make_app(rebuild_pdf)
     result = runner.invoke(app, [str(missing)])
     assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# PdfBuildError (ディスク容量不足) のハンドリング
+# ---------------------------------------------------------------------------
+
+
+@patch("kindle_cap.cli.orchestrator_run")
+def test_capture_pdf_build_error_exits_nonzero_with_message(
+    mock_run: MagicMock, tmp_path: Path
+) -> None:
+    """PDF 生成が ENOSPC で失敗したら exit 1 + 説明的メッセージを stderr に出す."""
+    mock_run.side_effect = PdfBuildError("ディスク容量不足で PDF を作成できませんでした。")
+    app = _make_app(capture)
+    result = runner.invoke(
+        app,
+        ["--name", "x", "--pages", "1", "--direction", "rtl", "--out", str(tmp_path)],
+    )
+    assert result.exit_code != 0
+    assert "ディスク容量不足" in result.output
+
+
+@patch("kindle_cap.cli.build_pdf")
+def test_rebuild_pdf_build_error_exits_nonzero_with_message(
+    mock_build: MagicMock, tmp_path: Path
+) -> None:
+    """rebuild_pdf でも ENOSPC は exit 1 + 説明的メッセージ."""
+    mock_build.side_effect = PdfBuildError("ディスク容量不足で PDF を作成できませんでした。")
+    book = tmp_path / "my-book"
+    book.mkdir()
+    (book / "page_001.png").write_bytes(b"a")
+
+    app = _make_app(rebuild_pdf)
+    result = runner.invoke(app, [str(book)])
+
+    assert result.exit_code != 0
+    assert "ディスク容量不足" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_pdf.py
+++ b/tests/unit/test_pdf.py
@@ -1,10 +1,12 @@
+import errno
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from PIL import Image
 from pypdf import PdfReader
 
-from kindle_cap.pdf import build_pdf
+from kindle_cap.pdf import PdfBuildError, build_pdf
 
 
 @pytest.fixture
@@ -163,3 +165,98 @@ def test_build_pdf_preserves_page_order(tmp_path: Path) -> None:
     reader = PdfReader(str(out))
     assert len(reader.pages) == 3
     # 順序の本格検証は PDF 内画像抽出が必要 — ここではページ数のみで妥協
+
+
+# ---------------------------------------------------------------------------
+# ディスク容量不足 (ENOSPC) ハンドリング
+# ---------------------------------------------------------------------------
+
+
+def test_pdf_build_error_is_exception_subclass() -> None:
+    assert issubclass(PdfBuildError, Exception)
+
+
+def test_build_pdf_raises_pdf_build_error_on_enospc(tmp_path: Path) -> None:
+    """img2pdf が ENOSPC で OSError を投げたら PdfBuildError に変換される."""
+    p = _make_rgb_png(tmp_path / "page_001.png")
+    out = tmp_path / "out.pdf"
+
+    enospc = OSError(errno.ENOSPC, "No space left on device")
+    with (
+        patch("kindle_cap.pdf.img2pdf.convert", side_effect=enospc),
+        pytest.raises(PdfBuildError),
+    ):
+        build_pdf([p], out)
+
+
+def test_build_pdf_removes_partial_pdf_on_enospc(tmp_path: Path) -> None:
+    """ENOSPC 時、書きかけの PDF ファイルは残さない."""
+    p = _make_rgb_png(tmp_path / "page_001.png")
+    out = tmp_path / "out.pdf"
+
+    enospc = OSError(errno.ENOSPC, "No space left on device")
+    with (
+        patch("kindle_cap.pdf.img2pdf.convert", side_effect=enospc),
+        pytest.raises(PdfBuildError),
+    ):
+        build_pdf([p], out)
+
+    assert not out.exists(), "部分書き込みされた PDF は削除されているべき"
+
+
+def test_build_pdf_keeps_png_files_on_enospc(tmp_path: Path) -> None:
+    """ENOSPC 時、入力 PNG は削除しない (再生成のため)."""
+    p = _make_rgb_png(tmp_path / "page_001.png")
+    out = tmp_path / "out.pdf"
+
+    enospc = OSError(errno.ENOSPC, "No space left on device")
+    with (
+        patch("kindle_cap.pdf.img2pdf.convert", side_effect=enospc),
+        pytest.raises(PdfBuildError),
+    ):
+        build_pdf([p], out)
+
+    assert p.exists(), "入力 PNG は ENOSPC 時も保持される"
+
+
+def test_build_pdf_error_message_includes_png_directory(tmp_path: Path) -> None:
+    """エラーメッセージに PNG が残っている場所を含めて、ユーザーが再生成手順を分かる."""
+    p = _make_rgb_png(tmp_path / "page_001.png")
+    out = tmp_path / "out.pdf"
+
+    enospc = OSError(errno.ENOSPC, "No space left on device")
+    with (
+        patch("kindle_cap.pdf.img2pdf.convert", side_effect=enospc),
+        pytest.raises(PdfBuildError) as exc_info,
+    ):
+        build_pdf([p], out)
+
+    assert str(tmp_path) in str(exc_info.value)
+
+
+def test_build_pdf_reraises_non_enospc_oserror(tmp_path: Path) -> None:
+    """ENOSPC 以外の OSError は PdfBuildError に変換せず原例外を raise."""
+    p = _make_rgb_png(tmp_path / "page_001.png")
+    out = tmp_path / "out.pdf"
+
+    other = OSError(errno.EACCES, "Permission denied")
+    with (
+        patch("kindle_cap.pdf.img2pdf.convert", side_effect=other),
+        pytest.raises(OSError) as exc_info,
+    ):
+        build_pdf([p], out)
+
+    assert not isinstance(exc_info.value, PdfBuildError)
+    assert exc_info.value.errno == errno.EACCES
+
+
+def test_build_pdf_removes_partial_pdf_on_other_oserror(tmp_path: Path) -> None:
+    """ENOSPC 以外の OSError でも部分書き込み PDF は削除される."""
+    p = _make_rgb_png(tmp_path / "page_001.png")
+    out = tmp_path / "out.pdf"
+
+    other = OSError(errno.EIO, "I/O error")
+    with patch("kindle_cap.pdf.img2pdf.convert", side_effect=other), pytest.raises(OSError):
+        build_pdf([p], out)
+
+    assert not out.exists(), "原例外 OSError でも部分 PDF は削除する"


### PR DESCRIPTION
## Summary

- `kindle_cap.pdf.PdfBuildError` 例外を新設し、`build_pdf` で `OSError` をキャッチ
- `errno.ENOSPC` の場合は日本語の説明的メッセージ + PNG 残存場所を含めて `PdfBuildError` を raise
- 部分書き込みされた PDF は `errno` に関係なく削除し、PNG は保持して `kindle-cap-pdf` で再生成可能に
- `cli.capture` / `cli.rebuild_pdf` で `PdfBuildError` を catch して `typer.Exit(1)`
- `CHANGELOG.md` の Unreleased に `Fixed` セクションを追加

Closes #19

## Test plan

- [x] `tests/unit/test_pdf.py` に 7 件追加 (red→green)
  - `PdfBuildError` が `Exception` のサブクラス
  - ENOSPC で `PdfBuildError` raise
  - ENOSPC で部分 PDF 削除
  - ENOSPC で入力 PNG は保持
  - エラーメッセージに PNG ディレクトリパスを含む
  - ENOSPC 以外の `OSError` は原例外を raise
  - ENOSPC 以外でも部分 PDF を削除
- [x] `tests/unit/test_cli.py` に 2 件追加: `capture` / `rebuild_pdf` 双方で `PdfBuildError` を catch して exit 1 + 説明的メッセージ
- [x] `uv run pytest tests/unit/ -q` → 243 passed
- [x] `uv run ruff check src/ tests/` → All checks passed
- [x] `uv run ruff format --check src/ tests/` → 44 files already formatted
- [x] `uv run mypy src/` → Success
- [x] `uv run pre-commit run --files <changed>` → all hooks pass

## 設計メモ

- mock は `kindle_cap.pdf.img2pdf.convert` だけ patch して `OSError(errno.ENOSPC, ...)` を side_effect に設定する形で最小限。実 ENOSPC 環境を作る代替手段が現実的でないため。
- `build_pdf` のシグネチャは不変。呼び出し元 (`orchestrator._capture_book`) は何も変えなくてよく、未捕捉のまま `cli` まで上がって catch される構造。