### PR TITLE
docs(ocr-bench): markdownlint 警告 5 件を解消 (closes #20)

### DIFF
--- a/docs/ocr-bench/2026-04-28.md
+++ b/docs/ocr-bench/2026-04-28.md
@@ -84,7 +84,7 @@
 
 縦書き本文サンプル (page_003 抜粋):
 
-```
+```text
 # 優れた知的生産に共通すること
 
 はじめに
@@ -94,7 +94,7 @@
 
 横書き本文サンプル (page_005 抜粋):
 
-```
+```text
 # はじめに
 
 近年、自然言語処理\(Natural Language Processing; NLP\) は目覚ましい進歩を遂げており、その<br>中核を担う大規模言語モデル\(Large Language Model; LLM\) の登場は、さまざまな革新をもたらし<br>ました。
@@ -102,11 +102,12 @@
 
 ### CLI コマンド
 
-```
+```bash
 yomitoku <png_dir_or_file> -f md -o <out_dir> -d mps --reading_order auto [--ignore_meta] [--ignore_ruby]
 ```
 
 主要オプション:
+
 - `-f md`: Markdown 出力
 - `-d mps|cpu|cuda`: デバイス
 - `--reading_order auto|left2right|top2bottom|right2left`: 縦書き対応
@@ -138,7 +139,7 @@ VIRTUAL_ENV=$(pwd)/experiments/ocr-poc/.venv-paddleocr uv pip install paddleocr 
 | 縦書き耐性 | ○ 以上必要 | ◎ | YomiToku 確定 |
 | 「Kindle 以外でも使いたい」 | 確定なら C | 設計上は汎用化可、ただし当面は Kindle 用途 | **B (将来 C に昇格できる構造)** |
 
-**結論: B 案 (同リポ別パッケージ別 CLI)**
+### 結論: B 案 (同リポ別パッケージ別 CLI)
 
 - `kindle-calibre-tool` リポを継続使用、新たに `src/book_ocr/` パッケージと `book-ocr` CLI を追加
 - `kindle_cap` は完全に不変


### PR DESCRIPTION
## Summary

- `docs/ocr-bench/2026-04-28.md` の markdownlint 警告 5 件を解消
- L87 / L97 (MD040): yomitoku 出力 Markdown サンプルの fenced code を ` ```text ` に
- L105 (MD040): yomitoku CLI コマンドの fenced code を ` ```bash ` に
- L109-110 (MD032): 「主要オプション:」と list の間に空行を挿入
- L141 (MD036): `**結論: B 案 ...**` (emphasis) を `### 結論: B 案 ...` (heading) に変更

Closes #20

## Test plan

- [x] `npx markdownlint-cli docs/ocr-bench/2026-04-28.md` で 0 警告
- [x] `uv run pre-commit run --files docs/ocr-bench/2026-04-28.md` 全 pass