### PR TITLE
fix(book-ocr): yomitoku subprocess の stderr 握り潰し / timeout 未設定 (closes #21)

### DIFF
--- a/src/book_ocr/engines/yomitoku.py
+++ b/src/book_ocr/engines/yomitoku.py
@@ -19,6 +19,8 @@ class YomiTokuEngine:
     reading_order: str = "auto"
     ignore_meta: bool = True
     yomitoku_bin: Path | None = None  # 隔離 venv のバイナリを指す用
+    # 1 ページ ~8 秒 × 200 ページ + 余裕で 30 分。巨大本では呼び出し側で延長
+    timeout_sec: float = 1800.0
 
     @property
     def name(self) -> str:
@@ -54,7 +56,21 @@ class YomiTokuEngine:
             if self.ignore_meta:
                 cmd.append("--ignore_meta")
 
-            subprocess.run(cmd, check=True, capture_output=True, text=True)
+            try:
+                result = subprocess.run(
+                    cmd,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=self.timeout_sec,
+                )
+            except subprocess.TimeoutExpired as e:
+                raise RuntimeError(
+                    f"yomitoku timeout (exceeded {self.timeout_sec}s). "
+                    f"巨大本では timeout_sec を延長するか、ページ数を分割してください。"
+                ) from e
+
+            _ensure_yomitoku_succeeded(result.returncode, result.stdout, result.stderr)
 
             return _collect_pages(pngs, output_dir, input_dir.name, engine_name=self.name)
 
@@ -71,6 +87,17 @@ class YomiTokuEngine:
                 f"{_BINARY_NAME} not found in PATH. Install with: uv pip install yomitoku"
             )
         return Path(path)
+
+
+def _ensure_yomitoku_succeeded(returncode: int, stdout: str, stderr: str) -> None:
+    """yomitoku subprocess の戻り値を検査し、非ゼロ exit なら RuntimeError を raise.
+
+    純粋関数として切り出しているので unit test で実 subprocess なしに網羅できる。
+    """
+    if returncode != 0:
+        raise RuntimeError(
+            f"yomitoku failed (exit={returncode}):\nstdout: {stdout}\nstderr: {stderr}"
+        )
 
 
 def _collect_pages(

--- a/tests/unit/test_book_ocr_yomitoku.py
+++ b/tests/unit/test_book_ocr_yomitoku.py
@@ -1,0 +1,93 @@
+"""YomiTokuEngine の subprocess 結果ハンドリング (純粋関数) のテスト."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from book_ocr.engines.yomitoku import (
+    YomiTokuEngine,
+    _ensure_yomitoku_succeeded,
+)
+
+# ---------------------------------------------------------------------------
+# _ensure_yomitoku_succeeded (純粋関数)
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureYomitokuSucceeded:
+    def test_does_not_raise_on_zero_returncode(self) -> None:
+        # 何も raise しないこと (戻り値 None)
+        assert _ensure_yomitoku_succeeded(0, "ok", "") is None
+
+    def test_does_not_raise_when_stderr_present_but_returncode_zero(self) -> None:
+        """yomitoku は warning を stderr に書きつつ exit 0 を返すことがある.
+
+        returncode=0 なら成功とみなす (stderr 内容に関わらず)。
+        """
+        assert _ensure_yomitoku_succeeded(0, "", "warning: deprecated") is None
+
+    def test_raises_runtime_error_on_nonzero_returncode(self) -> None:
+        with pytest.raises(RuntimeError):
+            _ensure_yomitoku_succeeded(1, "out", "err")
+
+    def test_error_message_contains_exit_code(self) -> None:
+        with pytest.raises(RuntimeError, match="exit=1"):
+            _ensure_yomitoku_succeeded(1, "", "")
+
+    def test_error_message_contains_negative_exit_code(self) -> None:
+        """SIGKILL (-9) など負の exit code もメッセージに出る."""
+        with pytest.raises(RuntimeError, match="exit=-9"):
+            _ensure_yomitoku_succeeded(-9, "", "killed by signal 9")
+
+    def test_error_message_contains_stdout(self) -> None:
+        with pytest.raises(RuntimeError, match="UNIQUE_STDOUT_TOKEN"):
+            _ensure_yomitoku_succeeded(2, "UNIQUE_STDOUT_TOKEN", "")
+
+    def test_error_message_contains_stderr(self) -> None:
+        with pytest.raises(RuntimeError, match="UNIQUE_STDERR_TOKEN"):
+            _ensure_yomitoku_succeeded(2, "", "UNIQUE_STDERR_TOKEN")
+
+
+# ---------------------------------------------------------------------------
+# YomiTokuEngine.timeout_sec デフォルト / カスタム
+# ---------------------------------------------------------------------------
+
+
+class TestYomiTokuEngineTimeoutSec:
+    def test_default_timeout_is_1800_seconds(self) -> None:
+        """デフォルト 30 分: 1 ページ ~8 秒 × 200 ページ + 余裕."""
+        assert YomiTokuEngine().timeout_sec == 1800.0
+
+    def test_custom_timeout_is_respected(self) -> None:
+        engine = YomiTokuEngine(timeout_sec=60.0)
+        assert engine.timeout_sec == 60.0
+
+
+# ---------------------------------------------------------------------------
+# subprocess.TimeoutExpired を RuntimeError に変換
+# ---------------------------------------------------------------------------
+
+
+class TestRunBatchTimeoutHandling:
+    def test_timeout_expired_is_converted_to_runtime_error(self, tmp_path: Path) -> None:
+        """yomitoku がハングしたら timeout で RuntimeError に変換される."""
+        # 偽 yomitoku binary (実行可能)
+        fake_bin = tmp_path / "yomitoku"
+        fake_bin.write_text("#!/bin/sh\nexit 0\n")
+        fake_bin.chmod(0o755)
+
+        png = tmp_path / "page_001.png"
+        png.write_bytes(b"")
+
+        engine = YomiTokuEngine(yomitoku_bin=fake_bin, timeout_sec=0.001)
+
+        timeout_error = subprocess.TimeoutExpired(cmd=["yomitoku"], timeout=0.001)
+        with (
+            patch("book_ocr.engines.yomitoku.subprocess.run", side_effect=timeout_error),
+            pytest.raises(RuntimeError, match="timeout"),
+        ):
+            engine.run_batch([png])


### PR DESCRIPTION
## Summary

- `YomiTokuEngine` に `timeout_sec: float = 1800.0` (30 分) を追加
- `subprocess.run(check=True)` を `check=False` + `timeout=self.timeout_sec` に変更
- `subprocess.TimeoutExpired` を `RuntimeError("yomitoku timeout (exceeded ...s) ...")` に変換
- subprocess の戻り値検証を `_ensure_yomitoku_succeeded(returncode, stdout, stderr)` 純粋関数に切り出し、非ゼロ exit で `stdout`/`stderr`/`exit code` を含む `RuntimeError` を raise
- 純粋関数化により mock なしの unit test で網羅 (TimeoutExpired のみ subprocess.run mock を使用)

Closes #21

## Test plan

- [x] `tests/unit/test_book_ocr_yomitoku.py` を新設 (10 件、全 pass)
  - `_ensure_yomitoku_succeeded` の境界値: returncode=0/1/-9, stdout/stderr の含有確認
  - `YomiTokuEngine.timeout_sec` のデフォルト/カスタム
  - `TimeoutExpired` → `RuntimeError("timeout")`
- [x] `uv run pytest tests/unit/ -q` → 244 passed
- [x] `uv run ruff check src/ tests/` → All checks passed
- [x] `uv run ruff format --check src/ tests/` → 45 files already formatted
- [x] `uv run mypy src/` → Success
- [x] `uv run pre-commit run --files <changed>` → all hooks pass

## 設計メモ

- メモリ "TDD は mock 最小限" に従い、subprocess の戻り値検証を純粋関数 `_ensure_yomitoku_succeeded` として切り出し。これで「非ゼロ exit のメッセージ」「stdout/stderr 含有」「負の exit code」などの境界値を mock なしで網羅できる。
- `subprocess.TimeoutExpired` ハンドリングだけは subprocess.run を mock する unit test を 1 件用意 (実 timeout を待つテストは遅い + 非決定的)。
- 実 yomitoku を叩く挙動検証は既存 `tests/integration/test_book_ocr_yomitoku.py` の live_ocr テストでカバー。

## 後続 issue との関連

- #24 (refactor) で `_collect_pages` の `input_dir_name` 引数削除を予定。本 PR では既存挙動を維持。