### PR TITLE
fix(book-ocr): live_ocr marker の過剰 gating で yomitoku 不要 test までスキップされる (closes #22)

### DIFF
--- a/tests/integration/test_book_ocr_yomitoku.py
+++ b/tests/integration/test_book_ocr_yomitoku.py
@@ -3,6 +3,8 @@
 @pytest.mark.live_ocr で gating。CI ではスキップ。ローカルで
 experiments/ocr-poc/.venv-yomitoku/bin/yomitoku が存在し、サンプル PNG が
 experiments/ocr-poc/samples-vertical/ にある場合のみ実行される。
+
+live_ocr 不要なユニットテストは tests/unit/test_book_ocr_engine.py にある (issue #22)。
 """
 
 from __future__ import annotations
@@ -13,7 +15,6 @@ from pathlib import Path
 import pytest
 
 from book_ocr.engines.yomitoku import YomiTokuEngine
-from book_ocr.protocols import OCREngine
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 _POC_VENV_BIN = REPO_ROOT / "experiments" / "ocr-poc" / ".venv-yomitoku" / "bin" / "yomitoku"
@@ -21,11 +22,6 @@ _SAMPLE_PNG = REPO_ROOT / "experiments" / "ocr-poc" / "samples-vertical" / "page
 
 
 pytestmark = pytest.mark.live_ocr
-
-
-def test_engine_satisfies_protocol() -> None:
-    engine = YomiTokuEngine()
-    assert isinstance(engine, OCREngine)
 
 
 def test_run_batch_single_page(tmp_path: Path) -> None:
@@ -44,16 +40,3 @@ def test_run_batch_single_page(tmp_path: Path) -> None:
     assert pages[0].page_number == 1
     assert pages[0].ocr_engine == "yomitoku"
     assert pages[0].markdown.strip() != ""
-
-
-def test_run_batch_empty_returns_empty_list() -> None:
-    """空入力では subprocess を呼ばずに空リストを返す."""
-    engine = YomiTokuEngine()
-    assert engine.run_batch([]) == []
-
-
-def test_resolve_binary_raises_when_missing(tmp_path: Path) -> None:
-    bad_path = tmp_path / "does-not-exist"
-    engine = YomiTokuEngine(yomitoku_bin=bad_path)
-    with pytest.raises(FileNotFoundError, match="does not exist"):
-        engine.run_batch([Path("/tmp/page_001.png")])

--- a/tests/unit/test_book_ocr_engine.py
+++ b/tests/unit/test_book_ocr_engine.py
@@ -1,0 +1,32 @@
+"""YomiTokuEngine の live_ocr 不要なユニットテスト.
+
+`tests/integration/test_book_ocr_yomitoku.py` から、yomitoku バイナリを呼ばずに
+完結するテストを移動 (issue #22)。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from book_ocr.engines.yomitoku import YomiTokuEngine
+from book_ocr.protocols import OCREngine
+
+
+def test_engine_satisfies_protocol() -> None:
+    engine = YomiTokuEngine()
+    assert isinstance(engine, OCREngine)
+
+
+def test_run_batch_empty_returns_empty_list() -> None:
+    """空入力では subprocess を呼ばずに空リストを返す."""
+    engine = YomiTokuEngine()
+    assert engine.run_batch([]) == []
+
+
+def test_resolve_binary_raises_when_missing(tmp_path: Path) -> None:
+    bad_path = tmp_path / "does-not-exist"
+    engine = YomiTokuEngine(yomitoku_bin=bad_path)
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        engine.run_batch([Path("/tmp/page_001.png")])


### PR DESCRIPTION
## Summary

- `tests/integration/test_book_ocr_yomitoku.py` の以下 3 件を `tests/unit/test_book_ocr_engine.py` に移動 (live_ocr marker を外す)
  - `test_engine_satisfies_protocol`: `isinstance` チェックのみ
  - `test_run_batch_empty_returns_empty_list`: 空入力で early return
  - `test_resolve_binary_raises_when_missing`: 存在しないパスで `FileNotFoundError`
- `tests/integration/test_book_ocr_yomitoku.py` には実 OCR が必要な `test_run_batch_single_page` のみ残す
- これにより CI (現状 `tests/unit/` のみ実行) でも上記 3 件のリグレッション検出が回る

Closes #22

## Test plan

- [x] `uv run pytest tests/unit/ -q` → 237 passed (+3 件分の収束)
- [x] `uv run pytest tests/unit/test_book_ocr_engine.py tests/integration/test_book_ocr_yomitoku.py -v` → 4 passed (live OCR は yomitoku binary が手元にあれば実行)
- [x] `uv run ruff check src/ tests/` → All checks passed
- [x] `uv run ruff format --check src/ tests/` → 45 files already formatted
- [x] `uv run mypy src/` → Success
- [x] `uv run pre-commit run --files <changed>` → all hooks pass

## 設計メモ

- issue 内には「CI では `pytest -m "not live_ocr"` でスキップされる」と記述があるが、実際の CI (`uv run pytest tests/unit/ -v --tb=short`) は `tests/unit/` だけを対象にしているため、live_ocr marker は実質「ドキュメンテーション目的」となっていた。それでも本 PR の split は CI で 3 件を検出可能にする効果があるので、issue の趣旨どおり対応。