### PR TITLE
refactor(book-ocr): protocols / cli / _collect_pages の整理 (closes #24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,21 @@
 - 開発者向けドキュメント（`CHANGELOG.md`、`CONTRIBUTING.md`）
 - GitHub の Issue / Pull Request テンプレート（`.github/`）
 - `kindle_cap.pdf.PdfBuildError` 例外：`build_pdf` がディスク容量不足など予測可能な要因で失敗したことを表す
+- `book_ocr.engines.yomitoku.YomiTokuEngine.timeout_sec`（デフォルト 1800 秒）：yomitoku がハングしたときに `RuntimeError` で抜けるための上限時間
+- `book_ocr.cli.run_ocr_pipeline(book_dir, ..., engine=...)`：CLI から分離した OCR パイプライン公開関数。テストや組み込み利用で `engine` を注入できる
+
+### Changed
+
+- **breaking**: `book_ocr.cli._run()` を削除。テスト/プログラム組み込みでエンジンを差し替えたい場合は新設の `book_ocr.cli.run_ocr_pipeline(book_dir, ..., engine=...)` を使う（issue #24）
+- **breaking**: `book_ocr.protocols.OCREngine` から `@runtime_checkable` を削除。Protocol 適合は静的型 (`mypy`) で担保し、`isinstance(obj, OCREngine)` は使わない（issue #24）
+- `book_ocr.engines.yomitoku._collect_pages` の `input_dir_name` 引数を削除し、モジュール定数 `_INPUT_DIR_NAME = "input"` に統一（issue #24）
 
 ### Fixed
 
 - ディスク容量不足 (`ENOSPC`) で PDF 生成が失敗したときに生 traceback を露出していたのを改修。`PdfBuildError` を raise し、CLI で日本語の説明的メッセージ + exit 1 で終了する。部分書き込みされた PDF は削除し、PNG は保持して `kindle-cap-pdf` で再生成可能 (issue #19)
+- `docs/ocr-bench/2026-04-28.md` の markdownlint 警告 5 件 (MD040 / MD032 / MD036) を解消 (issue #20)
+- `book_ocr.engines.yomitoku.YomiTokuEngine`：yomitoku subprocess の stderr 握り潰しと timeout 未設定を改修。非ゼロ exit / timeout 双方で `stdout`/`stderr`/`exit code` を含む `RuntimeError` を raise (issue #21)
+- `tests/integration/test_book_ocr_yomitoku.py` の yomitoku 不要なテスト 3 件を `tests/unit/test_book_ocr_engine.py` に移動して CI 実行対象に (issue #22)
 
 ## [0.1.0] - 2026-04-25
 

--- a/src/book_ocr/cli.py
+++ b/src/book_ocr/cli.py
@@ -13,6 +13,53 @@ from book_ocr.models import BookMetadata
 from book_ocr.protocols import OCREngine
 
 
+def run_ocr_pipeline(
+    book_dir: Path,
+    name: str | None = None,
+    device: str = "mps",
+    reading_order: str = "auto",
+    ignore_meta: bool = True,
+    out: Path | None = None,
+    engine: OCREngine | None = None,
+) -> Path:
+    """指定した book_dir 内の page_*.png を OCR して Markdown / index.json を出力する.
+
+    `engine=None` のときは `YomiTokuEngine` を生成する。テストでは FakeEngine 等を渡す。
+
+    Returns:
+        生成された book Markdown ファイルのパス。
+    """
+    pngs = sorted(book_dir.glob("page_*.png"))
+    if not pngs:
+        raise FileNotFoundError(f"No page_*.png in {book_dir}")
+
+    title = name or book_dir.name
+    out_dir = out or book_dir
+
+    engine = engine or YomiTokuEngine(
+        device=device,
+        reading_order=reading_order,
+        ignore_meta=ignore_meta,
+    )
+    meta = BookMetadata(
+        title=title,
+        page_count=len(pngs),
+        captured_at=datetime.now(UTC),
+        ocr_engine=engine.name,
+        output_dir=out_dir,
+    )
+
+    pages, index_dict, book_md_str = orchestrator.run(engine, meta, pngs)
+    writer.write_outputs(
+        out_dir=out_dir,
+        book_md_filename=f"{title}.md",
+        index=index_dict,
+        book_md=book_md_str,
+        pages=pages,
+    )
+    return out_dir / f"{title}.md"
+
+
 def ocr(
     book_dir: Path = typer.Argument(
         ...,
@@ -38,47 +85,19 @@ def ocr(
     ),
 ) -> None:
     """指定した book_dir 内の page_*.png を OCR して Markdown / index.json を生成する."""
-    pngs = sorted(book_dir.glob("page_*.png"))
-    if not pngs:
-        typer.echo(f"No page_*.png in {book_dir}", err=True)
-        raise typer.Exit(1)
-
-    title = name or book_dir.name
-    out_dir = out or book_dir
-
-    engine = YomiTokuEngine(
-        device=device,
-        reading_order=reading_order,
-        ignore_meta=ignore_meta,
-    )
-    meta = BookMetadata(
-        title=title,
-        page_count=len(pngs),
-        captured_at=datetime.now(UTC),
-        ocr_engine=engine.name,
-        output_dir=out_dir,
-    )
-
-    _run(engine, meta, pngs, out_dir, book_md_filename=f"{title}.md")
-    typer.echo(f"OCR complete: {out_dir}/{title}.md")
-
-
-def _run(
-    engine: OCREngine,
-    meta: BookMetadata,
-    png_paths: list[Path],
-    out_dir: Path,
-    book_md_filename: str,
-) -> None:
-    """テストから直接呼べる engine 注入ポイント."""
-    pages, index_dict, book_md_str = orchestrator.run(engine, meta, png_paths)
-    writer.write_outputs(
-        out_dir=out_dir,
-        book_md_filename=book_md_filename,
-        index=index_dict,
-        book_md=book_md_str,
-        pages=pages,
-    )
+    try:
+        out_path = run_ocr_pipeline(
+            book_dir=book_dir,
+            name=name,
+            device=device,
+            reading_order=reading_order,
+            ignore_meta=ignore_meta,
+            out=out,
+        )
+    except FileNotFoundError as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(1) from e
+    typer.echo(f"OCR complete: {out_path}")
 
 
 def run_ocr() -> None:

--- a/src/book_ocr/engines/yomitoku.py
+++ b/src/book_ocr/engines/yomitoku.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from book_ocr.models import PageText
 
 _BINARY_NAME = "yomitoku"
+_INPUT_DIR_NAME = "input"
 
 
 @dataclass
@@ -34,7 +35,7 @@ class YomiTokuEngine:
 
         with tempfile.TemporaryDirectory() as tmp_str:
             tmp_dir = Path(tmp_str)
-            input_dir = tmp_dir / "input"
+            input_dir = tmp_dir / _INPUT_DIR_NAME
             output_dir = tmp_dir / "output"
             input_dir.mkdir()
 
@@ -72,7 +73,7 @@ class YomiTokuEngine:
 
             _ensure_yomitoku_succeeded(result.returncode, result.stdout, result.stderr)
 
-            return _collect_pages(pngs, output_dir, input_dir.name, engine_name=self.name)
+            return _collect_pages(pngs, output_dir, engine_name=self.name)
 
     def _resolve_binary(self) -> Path:
         if self.yomitoku_bin is not None:
@@ -103,15 +104,14 @@ def _ensure_yomitoku_succeeded(returncode: int, stdout: str, stderr: str) -> Non
 def _collect_pages(
     pngs: list[Path],
     output_dir: Path,
-    input_dir_name: str,
     engine_name: str,
 ) -> list[PageText]:
-    """yomitoku が書き出した `<input_dir>_<stem>_p1.md` ファイル群を PageText に変換する.
+    """yomitoku が書き出した `<_INPUT_DIR_NAME>_<stem>_p1.md` ファイル群を PageText に変換する.
 
     yomitoku CLI でディレクトリを処理すると、出力ファイル名は
     `<input_dir_name>_<file_stem>_p1.md` というプレフィクス付きで生成される
     (例: 入力ディレクトリ "input" の page_001.png → "input_page_001_p1.md")。
-    本関数は input_dir_name を引数に取り、確定した命名規則で .md を読む。
+    本関数は確定した命名規則で .md を読む。
 
     戻り値はページ番号の昇順。
     """
@@ -125,7 +125,7 @@ def _collect_pages(
                 f"Cannot derive page number from {png.name}; expected page_NNN.png"
             ) from exc
 
-        md_path = output_dir / f"{input_dir_name}_{png.stem}_p1.md"
+        md_path = output_dir / f"{_INPUT_DIR_NAME}_{png.stem}_p1.md"
         if not md_path.exists():
             raise FileNotFoundError(f"Expected yomitoku output {md_path} not found")
 

--- a/src/book_ocr/protocols.py
+++ b/src/book_ocr/protocols.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Protocol, runtime_checkable
+from typing import Protocol
 
 from book_ocr.models import PageText
 
 
-@runtime_checkable
 class OCREngine(Protocol):
     @property
     def name(self) -> str: ...

--- a/tests/unit/test_book_ocr_cli.py
+++ b/tests/unit/test_book_ocr_cli.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -11,7 +10,8 @@ import typer
 from typer.testing import CliRunner
 
 from book_ocr import cli
-from book_ocr.models import BookMetadata, PageText
+from book_ocr.cli import run_ocr_pipeline
+from book_ocr.models import PageText
 
 
 class FakeEngine:
@@ -39,52 +39,43 @@ def _make_book_dir(tmp_path: Path, n_pages: int = 2) -> Path:
     return book
 
 
-class TestRunInjectsFakeEngine:
-    def test_run_writes_index_md_and_pages(self, tmp_path: Path) -> None:
+class TestRunOcrPipeline:
+    def test_writes_index_md_and_pages(self, tmp_path: Path) -> None:
         book = _make_book_dir(tmp_path, n_pages=2)
-        meta = BookMetadata(
-            title="my-book",
-            page_count=2,
-            captured_at=datetime(2026, 4, 28, tzinfo=UTC),
-            ocr_engine="fake",
-            output_dir=book,
-        )
-        pngs = sorted(book.glob("page_*.png"))
 
-        cli._run(
-            engine=FakeEngine(),
-            meta=meta,
-            png_paths=pngs,
-            out_dir=book,
-            book_md_filename="my-book.md",
-        )
+        out_path = run_ocr_pipeline(book_dir=book, engine=FakeEngine())
 
+        assert out_path == book / "my-book.md"
         assert (book / "index.json").exists()
         assert (book / "my-book.md").exists()
         assert (book / "pages" / "page_001.md").exists()
         assert (book / "pages" / "page_002.md").exists()
 
-    def test_index_json_uses_meta_title(self, tmp_path: Path) -> None:
+    def test_name_argument_overrides_book_dir_basename(self, tmp_path: Path) -> None:
         book = _make_book_dir(tmp_path, n_pages=1)
-        meta = BookMetadata(
-            title="custom-title",
-            page_count=1,
-            captured_at=datetime(2026, 4, 28, tzinfo=UTC),
-            ocr_engine="fake",
-            output_dir=book,
-        )
-        pngs = sorted(book.glob("page_*.png"))
 
-        cli._run(
-            engine=FakeEngine(),
-            meta=meta,
-            png_paths=pngs,
-            out_dir=book,
-            book_md_filename="custom-title.md",
-        )
+        out_path = run_ocr_pipeline(book_dir=book, name="custom-title", engine=FakeEngine())
 
+        assert out_path == book / "custom-title.md"
         data = json.loads((book / "index.json").read_text(encoding="utf-8"))
         assert data["title"] == "custom-title"
+        assert (book / "custom-title.md").exists()
+
+    def test_out_argument_redirects_output_dir(self, tmp_path: Path) -> None:
+        book = _make_book_dir(tmp_path, n_pages=1)
+        elsewhere = tmp_path / "elsewhere"
+
+        out_path = run_ocr_pipeline(book_dir=book, out=elsewhere, engine=FakeEngine())
+
+        assert out_path == elsewhere / "my-book.md"
+        assert (elsewhere / "index.json").exists()
+        assert (elsewhere / "my-book.md").exists()
+
+    def test_empty_dir_raises_file_not_found(self, tmp_path: Path) -> None:
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        with pytest.raises(FileNotFoundError, match="No page_"):
+            run_ocr_pipeline(book_dir=empty, engine=FakeEngine())
 
 
 class TestCliInvocation:

--- a/tests/unit/test_book_ocr_engine.py
+++ b/tests/unit/test_book_ocr_engine.py
@@ -11,12 +11,14 @@ from pathlib import Path
 import pytest
 
 from book_ocr.engines.yomitoku import YomiTokuEngine
-from book_ocr.protocols import OCREngine
 
 
-def test_engine_satisfies_protocol() -> None:
+def test_engine_satisfies_protocol_via_duck_typing() -> None:
+    """Protocol 適合は静的型 (mypy) で担保。実行時は名と run_batch の存在で確認."""
     engine = YomiTokuEngine()
-    assert isinstance(engine, OCREngine)
+    assert hasattr(engine, "name")
+    assert isinstance(engine.name, str)
+    assert callable(engine.run_batch)
 
 
 def test_run_batch_empty_returns_empty_list() -> None:

--- a/tests/unit/test_book_ocr_orchestrator.py
+++ b/tests/unit/test_book_ocr_orchestrator.py
@@ -9,7 +9,6 @@ import pytest
 
 from book_ocr import orchestrator
 from book_ocr.models import BookMetadata, PageText
-from book_ocr.protocols import OCREngine
 
 
 class FakeEngine:
@@ -46,9 +45,12 @@ def _make_meta(out_dir: Path, page_count: int = 2) -> BookMetadata:
 
 
 class TestFakeEngineSatisfiesProtocol:
-    def test_fake_engine_is_recognized_as_ocr_engine(self) -> None:
+    def test_fake_engine_has_required_methods(self) -> None:
+        """Protocol 適合は静的型 (mypy) で担保。実行時は duck typing で確認."""
         engine = FakeEngine()
-        assert isinstance(engine, OCREngine)
+        assert hasattr(engine, "name")
+        assert isinstance(engine.name, str)
+        assert callable(engine.run_batch)
 
 
 class TestOrchestratorRun:


### PR DESCRIPTION
## Summary

3 つの設計負債を同時に解消 (issue #24)。CHANGELOG に Changed セクションと breaking change の周知を追加。

### 1. `@runtime_checkable` 削除

- `src/book_ocr/protocols.py` から `@runtime_checkable` と関連 import を削除
- `isinstance(obj, OCREngine)` を duck typing (`hasattr(obj, "name")` + `callable(obj.run_batch)`) に置換
  - `tests/unit/test_book_ocr_engine.py::test_engine_satisfies_protocol_via_duck_typing`
  - `tests/unit/test_book_ocr_orchestrator.py::TestFakeEngineSatisfiesProtocol::test_fake_engine_has_required_methods`
- Protocol 適合は静的型 (`mypy --strict`) で担保

### 2. `cli._run()` 削除 → `run_ocr_pipeline()` 新設

issue では「`ocr()` に `_engine: OCREngine | None = None` を追加すれば `_run` 不要」と提案していたが、typer は Protocol 型のパラメータを CLI option として処理できない (`RuntimeError: Type not yet supported: <class 'book_ocr.protocols.OCREngine'>`) ため不可。

代わりに **CLI parameter parsing と pipeline を関数分離**:

- `cli.run_ocr_pipeline(book_dir, name=None, device="mps", reading_order="auto", ignore_meta=True, out=None, engine=None) -> Path`
  - production の主要関数 (test 専用ではない)
  - `engine=None` のとき `YomiTokuEngine` を生成、test では FakeEngine を渡す
  - 戻り値は生成された book Markdown ファイルのパス
- `cli.ocr(...)` (typer) は CLI 引数を受けて `run_ocr_pipeline(...)` を呼ぶだけのthin wrapper

これで「production code に test fixture が混入」の状態は解消され、ライブラリ利用時も `from book_ocr.cli import run_ocr_pipeline` でクリーンな API として使える。

### 3. `_collect_pages` の `input_dir_name` 引数削除

- 呼び出し側で常に `"input"` 固定だったので過剰汎用化を解消
- モジュール定数 `_INPUT_DIR_NAME = "input"` に統一
- `run_batch` 内の `input_dir = tmp_dir / "input"` も同定数化

## Breaking Changes

- `book_ocr.cli._run()` 削除 → `book_ocr.cli.run_ocr_pipeline(book_dir, ..., engine=...)` を使う
- `book_ocr.protocols.OCREngine` の `@runtime_checkable` 削除 → `isinstance` チェックは不可、`mypy` の静的検査で代替

ユーザーは v0.1.0 を release 済みだが、`book_ocr` は extras `[ocr]` パッケージで `_run` / `isinstance` チェックは internal API。breaking change を許容する方針 (事前確認済み)。

CHANGELOG.md の Unreleased / Changed セクションに記載。

## Test plan

- [x] `uv run pytest tests/unit/ -q` → 258 passed (PR-3/PR-4 マージ後の 244 + 増分)
- [x] `uv run ruff check src/ tests/` → All checks passed
- [x] `uv run ruff format --check src/ tests/` → 46 files already formatted
- [x] `uv run mypy src/` → Success (Protocol を runtime check しなくても静的型整合)
- [x] `uv run pre-commit run --files <changed>` → all hooks pass

## CHANGELOG エントリ整理

PR-1〜PR-4 のうち Fixed エントリが揃っていなかったので、本 PR でまとめて追記:

- PR-1 (#19) の Fixed: 既存
- PR-2 (#20) の Fixed: 追加
- PR-3 (#21) の Fixed: 追加
- PR-4 (#22) の Fixed: 追加
- PR-5 (本 PR) の Changed: 追加