### PR TITLE
refactor(book-ocr): test ヘルパー _make_meta を fixture 集約 (closes #23)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,12 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
 import pytest
+
+from book_ocr.models import BookMetadata
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
@@ -8,3 +16,29 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
     for item in items:
         if "live" in item.keywords:
             item.add_marker(skip_live)
+
+
+@pytest.fixture
+def make_meta() -> Callable[..., BookMetadata]:
+    """テスト用 BookMetadata factory.
+
+    test_book_ocr_orchestrator.py / test_book_ocr_exporters.py で重複していた
+    `_make_meta` を集約 (issue #23)。呼び出し側で `out_dir` / `ocr_engine` /
+    `page_count` / `title` を override できる。`captured_at` は決定論のため固定値。
+    """
+
+    def _make(
+        out_dir: Path = Path("/tmp/output/my-book"),
+        page_count: int = 2,
+        ocr_engine: str = "yomitoku",
+        title: str = "my-book",
+    ) -> BookMetadata:
+        return BookMetadata(
+            title=title,
+            page_count=page_count,
+            captured_at=datetime(2026, 4, 28, 21, 0, 0, tzinfo=UTC),
+            ocr_engine=ocr_engine,
+            output_dir=out_dir,
+        )
+
+    return _make

--- a/tests/unit/test_book_ocr_exporters.py
+++ b/tests/unit/test_book_ocr_exporters.py
@@ -1,7 +1,8 @@
-"""book_ocr.exporters の純粋関数テスト (TDD red)."""
+"""book_ocr.exporters の純粋関数テスト."""
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -19,16 +20,6 @@ def _make_page(
         png_path=out_dir / f"page_{n:03d}.png",
         markdown=markdown,
         ocr_engine="yomitoku",
-    )
-
-
-def _make_meta(page_count: int = 2) -> BookMetadata:
-    return BookMetadata(
-        title="my-book",
-        page_count=page_count,
-        captured_at=datetime(2026, 4, 28, 21, 0, 0, tzinfo=UTC),
-        ocr_engine="yomitoku",
-        output_dir=Path("/tmp/output/my-book"),
     )
 
 
@@ -82,21 +73,23 @@ class TestRenderBookMd:
 
 
 class TestRenderIndex:
-    def test_top_level_fields(self) -> None:
-        meta = _make_meta()
+    def test_top_level_fields(self, make_meta: Callable[..., BookMetadata]) -> None:
+        meta = make_meta()
         pages = [_make_page(1), _make_page(2)]
         result = render_index(meta, pages)
         assert result["title"] == "my-book"
         assert result["page_count"] == 2
         assert result["ocr_engine"] == "yomitoku"
 
-    def test_captured_at_is_iso8601(self) -> None:
-        meta = _make_meta()
+    def test_captured_at_is_iso8601(self, make_meta: Callable[..., BookMetadata]) -> None:
+        meta = make_meta()
         result = render_index(meta, [])
         assert result["captured_at"] == "2026-04-28T21:00:00+00:00"
 
-    def test_pages_entries_have_relative_paths(self) -> None:
-        meta = _make_meta()
+    def test_pages_entries_have_relative_paths(
+        self, make_meta: Callable[..., BookMetadata]
+    ) -> None:
+        meta = make_meta()
         pages = [_make_page(1), _make_page(2)]
         result = render_index(meta, pages)
         assert result["pages"] == [
@@ -104,14 +97,16 @@ class TestRenderIndex:
             {"n": 2, "png": "page_002.png", "md": "pages/page_002.md"},
         ]
 
-    def test_pages_zero_padding_at_three_digits(self) -> None:
-        meta = _make_meta(page_count=12)
+    def test_pages_zero_padding_at_three_digits(
+        self, make_meta: Callable[..., BookMetadata]
+    ) -> None:
+        meta = make_meta(page_count=12)
         pages = [_make_page(12)]
         result = render_index(meta, pages)
         assert result["pages"][0]["md"] == "pages/page_012.md"
 
-    def test_empty_pages_list(self) -> None:
-        meta = _make_meta(page_count=0)
+    def test_empty_pages_list(self, make_meta: Callable[..., BookMetadata]) -> None:
+        meta = make_meta(page_count=0)
         result = render_index(meta, [])
         assert result["pages"] == []
         assert result["page_count"] == 0

--- a/tests/unit/test_book_ocr_orchestrator.py
+++ b/tests/unit/test_book_ocr_orchestrator.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -34,16 +34,6 @@ class FakeEngine:
         return [self._one(p) for p in pngs]
 
 
-def _make_meta(out_dir: Path, page_count: int = 2) -> BookMetadata:
-    return BookMetadata(
-        title="my-book",
-        page_count=page_count,
-        captured_at=datetime(2026, 4, 28, 21, 0, 0, tzinfo=UTC),
-        ocr_engine="fake",
-        output_dir=out_dir,
-    )
-
-
 class TestFakeEngineSatisfiesProtocol:
     def test_fake_engine_has_required_methods(self) -> None:
         """Protocol 適合は静的型 (mypy) で担保。実行時は duck typing で確認."""
@@ -54,8 +44,10 @@ class TestFakeEngineSatisfiesProtocol:
 
 
 class TestOrchestratorRun:
-    def test_returns_one_page_per_png(self, tmp_path: Path) -> None:
-        meta = _make_meta(tmp_path)
+    def test_returns_one_page_per_png(
+        self, tmp_path: Path, make_meta: Callable[..., BookMetadata]
+    ) -> None:
+        meta = make_meta(out_dir=tmp_path, ocr_engine="fake")
         pngs = [tmp_path / "page_001.png", tmp_path / "page_002.png"]
         engine = FakeEngine()
 
@@ -65,8 +57,10 @@ class TestOrchestratorRun:
         assert pages[0].page_number == 1
         assert pages[1].page_number == 2
 
-    def test_returned_pages_use_engine_name(self, tmp_path: Path) -> None:
-        meta = _make_meta(tmp_path)
+    def test_returned_pages_use_engine_name(
+        self, tmp_path: Path, make_meta: Callable[..., BookMetadata]
+    ) -> None:
+        meta = make_meta(out_dir=tmp_path, ocr_engine="fake")
         pngs = [tmp_path / "page_001.png"]
         engine = FakeEngine()
 
@@ -74,8 +68,10 @@ class TestOrchestratorRun:
 
         assert pages[0].ocr_engine == "fake"
 
-    def test_index_dict_matches_render_index(self, tmp_path: Path) -> None:
-        meta = _make_meta(tmp_path)
+    def test_index_dict_matches_render_index(
+        self, tmp_path: Path, make_meta: Callable[..., BookMetadata]
+    ) -> None:
+        meta = make_meta(out_dir=tmp_path, ocr_engine="fake")
         pngs = [tmp_path / "page_001.png", tmp_path / "page_002.png"]
         engine = FakeEngine()
 
@@ -86,8 +82,10 @@ class TestOrchestratorRun:
         assert index["pages"][0]["png"] == "page_001.png"
         assert index["pages"][1]["md"] == "pages/page_002.md"
 
-    def test_book_md_contains_all_page_markers(self, tmp_path: Path) -> None:
-        meta = _make_meta(tmp_path, page_count=3)
+    def test_book_md_contains_all_page_markers(
+        self, tmp_path: Path, make_meta: Callable[..., BookMetadata]
+    ) -> None:
+        meta = make_meta(out_dir=tmp_path, ocr_engine="fake", page_count=3)
         pngs = [tmp_path / f"page_{n:03d}.png" for n in (1, 2, 3)]
         engine = FakeEngine()
 
@@ -99,9 +97,11 @@ class TestOrchestratorRun:
         assert "OCR text for page 1" in book_md
         assert "OCR text for page 3" in book_md
 
-    def test_no_side_effects_on_disk(self, tmp_path: Path) -> None:
+    def test_no_side_effects_on_disk(
+        self, tmp_path: Path, make_meta: Callable[..., BookMetadata]
+    ) -> None:
         """orchestrator は副作用ゼロ。writer に書き込みを委譲する."""
-        meta = _make_meta(tmp_path)
+        meta = make_meta(out_dir=tmp_path, ocr_engine="fake")
         pngs = [tmp_path / "page_001.png"]
         engine = FakeEngine()
 
@@ -110,8 +110,10 @@ class TestOrchestratorRun:
         # output_dir 配下に何も書き込まれていないこと
         assert list(tmp_path.iterdir()) == []
 
-    def test_empty_png_paths_returns_empty_lists(self, tmp_path: Path) -> None:
-        meta = _make_meta(tmp_path, page_count=0)
+    def test_empty_png_paths_returns_empty_lists(
+        self, tmp_path: Path, make_meta: Callable[..., BookMetadata]
+    ) -> None:
+        meta = make_meta(out_dir=tmp_path, ocr_engine="fake", page_count=0)
         engine = FakeEngine()
 
         pages, index, book_md = orchestrator.run(engine, meta, [])
@@ -120,7 +122,9 @@ class TestOrchestratorRun:
         assert index["pages"] == []
         assert book_md == ""
 
-    def test_engine_run_batch_called_exactly_once(self, tmp_path: Path) -> None:
+    def test_engine_run_batch_called_exactly_once(
+        self, tmp_path: Path, make_meta: Callable[..., BookMetadata]
+    ) -> None:
         """run_batch が 1 回だけ呼ばれることを確認 (バッチ最適化を保証)."""
         call_count = 0
 
@@ -142,7 +146,7 @@ class TestOrchestratorRun:
                     for p in pngs
                 ]
 
-        meta = _make_meta(tmp_path)
+        meta = make_meta(out_dir=tmp_path, ocr_engine="fake")
         pngs = [tmp_path / "page_001.png", tmp_path / "page_002.png"]
         orchestrator.run(CountingFakeEngine(), meta, pngs)
 
@@ -150,7 +154,9 @@ class TestOrchestratorRun:
 
 
 class TestOrchestratorRunInputValidation:
-    def test_rejects_engine_returning_wrong_page_number(self, tmp_path: Path) -> None:
+    def test_rejects_engine_returning_wrong_page_number(
+        self, tmp_path: Path, make_meta: Callable[..., BookMetadata]
+    ) -> None:
         """engine が png ファイル名と一致しない page_number を返した場合の挙動.
 
         現状仕様: engine が返した PageText をそのまま使う。
@@ -174,7 +180,7 @@ class TestOrchestratorRunInputValidation:
                     for p in pngs
                 ]
 
-        meta = _make_meta(tmp_path)
+        meta = make_meta(out_dir=tmp_path, ocr_engine="fake")
         pngs = [tmp_path / "page_001.png", tmp_path / "page_002.png"]
 
         with pytest.raises(ValueError, match="duplicate"):


### PR DESCRIPTION
## Summary

`tests/unit/test_book_ocr_orchestrator.py` と `tests/unit/test_book_ocr_exporters.py` で同名異実装だった `_make_meta` を `tests/conftest.py` の `make_meta` fixture に集約 (issue #23)。

### 統合 fixture の signature

```python
@pytest.fixture
def make_meta() -> Callable[..., BookMetadata]:
    def _make(
        out_dir: Path = Path("/tmp/output/my-book"),
        page_count: int = 2,
        ocr_engine: str = "yomitoku",
        title: str = "my-book",
    ) -> BookMetadata: ...
    return _make
```

`captured_at` は決定論のため固定値 (`datetime(2026, 4, 28, 21, 0, 0, tzinfo=UTC)`)。

### 各 test ファイルの移行

- `test_book_ocr_orchestrator.py`: ローカル `_make_meta(out_dir, page_count=2)` (`ocr_engine="fake"` 固定) を削除し、`make_meta(out_dir=tmp_path, ocr_engine="fake")` などに置換
- `test_book_ocr_exporters.py`: ローカル `_make_meta(page_count=2)` を削除し、`make_meta()` / `make_meta(page_count=N)` に置換 (default が exporters 側に合致)

`test_png_path_not_under_output_dir_does_not_crash` だけは `output_dir=Path("/elsewhere/output")` の特殊ケースを直接書き下す。

Closes #23

## Test plan

- [x] `uv run pytest tests/unit/ -q` → 258 passed (refactor 前と同件数)
- [x] `uv run ruff check src/ tests/` → All checks passed
- [x] `uv run ruff format --check src/ tests/` → 46 files already formatted
- [x] `uv run mypy src/` → Success
- [x] `uv run pre-commit run --files <changed>` → all hooks pass

## 設計メモ

- issue 内の優先度は「低」と書かれていたが、PR-5 直後の small refactor として一気に片付けると同名異実装による齟齬リスクを排除できる
- `make_meta` の default `ocr_engine="yomitoku"` は exporters 側の利用に合わせた (引数なし呼び出しが多いため)