### PR TITLE
chore(book-ocr): py.typed marker を追加して型情報を下流に公開

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - **breaking**: `book_ocr.cli._run()` を削除。テスト/プログラム組み込みでエンジンを差し替えたい場合は新設の `book_ocr.cli.run_ocr_pipeline(book_dir, ..., engine=...)` を使う（issue #24）
 - **breaking**: `book_ocr.protocols.OCREngine` から `@runtime_checkable` を削除。Protocol 適合は静的型 (`mypy`) で担保し、`isinstance(obj, OCREngine)` は使わない（issue #24）
 - `book_ocr.engines.yomitoku._collect_pages` の `input_dir_name` 引数を削除し、モジュール定数 `_INPUT_DIR_NAME = "input"` に統一（issue #24）
+- `book_ocr` パッケージに `py.typed` marker を追加。下流プロジェクトおよび当リポジトリの `tests/` で `book_ocr.*` の型情報が認識されるようになる（issue #11）
 
 ### Fixed
 

--- a/tests/unit/test_book_ocr_yomitoku.py
+++ b/tests/unit/test_book_ocr_yomitoku.py
@@ -21,14 +21,14 @@ from book_ocr.engines.yomitoku import (
 class TestEnsureYomitokuSucceeded:
     def test_does_not_raise_on_zero_returncode(self) -> None:
         # 何も raise しないこと (戻り値 None)
-        assert _ensure_yomitoku_succeeded(0, "ok", "") is None
+        _ensure_yomitoku_succeeded(0, "ok", "")
 
     def test_does_not_raise_when_stderr_present_but_returncode_zero(self) -> None:
         """yomitoku は warning を stderr に書きつつ exit 0 を返すことがある.
 
         returncode=0 なら成功とみなす (stderr 内容に関わらず)。
         """
-        assert _ensure_yomitoku_succeeded(0, "", "warning: deprecated") is None
+        _ensure_yomitoku_succeeded(0, "", "warning: deprecated")
 
     def test_raises_runtime_error_on_nonzero_returncode(self) -> None:
         with pytest.raises(RuntimeError):


### PR DESCRIPTION
## Summary

`book_ocr` パッケージに `py.typed` marker (空ファイル) を追加。

- 当リポジトリの `tests/` で `book_ocr.*` の `[import-untyped]` 警告が消える
- 下流プロジェクトも mypy で `book_ocr.*` の型情報を認識できるようになる

副次的に、`tests/unit/test_book_ocr_yomitoku.py` の `assert _ensure_yomitoku_succeeded(...) is None` を関数呼び出しのみに変更。`-> None` の戻り値を assert する慣用句が mypy strict の `[func-returns-value]` に引っかかるため、テストの意図 (raise しない確認) は呼び出しだけで担保する形に整理。

## 効果

`uv run mypy tests/` のエラー件数:

- **90 errors → 73 errors** (17 件解消)
- 内訳:
  - `[import-untyped]` 14 件 (`book_ocr.*` 系)
  - `[unused-ignore]` 2 件 (`book_ocr.models` が型認識されたため不要警告解消)
  - `[func-returns-value]` 1 件 (`assert ... is None` 削除)

## Refs

Refs #11 — テストヘルパー関数の型注釈追加で `mypy tests/` を 0 errors にする。本 PR は段階対応の **2/5** で、残り PR-C/D/E で `test_orchestrator` / `test_config` / `test_capture` 等の型注釈を順次追加。最終 PR で `Closes #11`。

## Test plan

- [x] `uv run mypy tests/` で 17 件減少を確認 (90 → 73)
- [x] `uv run pytest tests/unit/ -q` → 258 passed (デグレなし)
- [x] `uv run ruff check src/ tests/` → All checks passed
- [x] `uv run ruff format --check src/ tests/` → 46 files already formatted
- [ ] `gh pr checks` → 全 green