### PR TITLE
refactor(tests): test_config.py の Direction 比較と _valid_config_kwargs に型注釈

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -10,8 +11,8 @@ from kindle_cap.config import CaptureConfig, Direction, Geometry
 
 
 def test_direction_string_values() -> None:
-    assert Direction.RTL == "rtl"
-    assert Direction.LTR == "ltr"
+    assert Direction.RTL.value == "rtl"
+    assert Direction.LTR.value == "ltr"
 
 
 def test_direction_has_only_two_values() -> None:
@@ -53,8 +54,8 @@ def test_geometry_hashable() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _valid_config_kwargs(**overrides):
-    base = dict(
+def _valid_config_kwargs(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = dict(
         name="my-book",
         pages=10,
         direction=Direction.RTL,


### PR DESCRIPTION
## Summary

`tests/unit/test_config.py` の 2 箇所を改修して mypy strict 警告を 25 件解消。

### 1. Direction enum と str literal の比較 (L13-14)

`Direction.RTL == "rtl"` は mypy 的に「型として重ならない」(`[comparison-overlap]`) と判定されるため、`.value` を介した比較に変更。テストの意図 (Direction enum の文字列値が `"rtl"` / `"ltr"` であることを確認) はそのまま。

### 2. `_valid_config_kwargs` ヘルパーの型注釈 (L56)

`**overrides: Any` と戻り値 `-> dict[str, Any]` を追加。内部の `base = dict(...)` も `base: dict[str, Any]` と annotate。これによりこのヘルパーを呼ぶ 22 箇所の `[no-untyped-call]` が連鎖解消。

ロジック変更なし。

## 効果

`uv run mypy tests/` のエラー件数:

- **35 errors → 10 errors** (25 件解消)
- 内訳:
  - `[no-untyped-call]` 22 件 (`_valid_config_kwargs` 呼び出しの連鎖)
  - `[no-untyped-def]` 1 件 (`_valid_config_kwargs` 定義)
  - `[comparison-overlap]` 2 件 (Direction.RTL/LTR == 文字列)

## Refs

Refs #11 — テスト型注釈で `mypy tests/` を 0 errors に。本 PR は段階対応の **4/5**。次の PR-E で残り 10 件を解消し `Closes #11`。

## Test plan

- [x] `uv run mypy tests/unit/test_config.py` → Success: no issues found
- [x] `uv run mypy tests/` で 25 件減少を確認 (35 → 10)
- [x] `uv run pytest tests/unit/test_config.py -q` → 27 passed (デグレなし)
- [x] `uv run ruff check tests/unit/test_config.py` → All checks passed
- [x] `uv run ruff format --check tests/unit/test_config.py` → already formatted
- [ ] `gh pr checks` → 全 green