### PR TITLE
refactor(tests): test_capture / cli / pdf / preflight に型注釈を追加 (closes #11)

### DIFF
--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -1,5 +1,7 @@
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -152,8 +154,8 @@ def test_flatten_alpha_replaces_transparent_with_white_background(tmp_path: Path
 # ---------------------------------------------------------------------------
 
 
-def _stub_screencapture_factory(out_path: Path, mode: str = "RGBA"):
-    def side_effect(cmd, **kwargs):
+def _stub_screencapture_factory(out_path: Path, mode: str = "RGBA") -> Callable[..., None]:
+    def side_effect(cmd: list[str], **kwargs: Any) -> None:
         Image.new(mode, (10, 10), "red" if mode == "RGB" else (255, 0, 0, 200)).save(out_path)
 
     return side_effect

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -11,7 +12,7 @@ from kindle_cap.pdf import PdfBuildError
 runner = CliRunner()
 
 
-def _make_app(func) -> typer.Typer:
+def _make_app(func: Callable[..., None]) -> typer.Typer:
     app = typer.Typer()
     app.command()(func)
     return app

--- a/tests/unit/test_pdf.py
+++ b/tests/unit/test_pdf.py
@@ -1,5 +1,6 @@
 import errno
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -103,11 +104,11 @@ def test_build_pdf_streams_to_disk_without_loading_full_bytes_into_memory(
     import img2pdf
 
     pngs = [_make_rgb_png(tmp_path / "x.png")]
-    captured_kwargs: dict = {}
+    captured_kwargs: dict[str, Any] = {}
 
     real_convert = img2pdf.convert
 
-    def spy(*args, **kwargs):
+    def spy(*args: Any, **kwargs: Any) -> Any:
         captured_kwargs.update(kwargs)
         return real_convert(*args, **kwargs)
 

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -1,6 +1,7 @@
 import subprocess
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -87,11 +88,11 @@ def test_is_accessibility_error_handles_none_safely() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _run_factory(outputs: list):
+def _run_factory(outputs: list[str | BaseException]) -> Callable[..., MagicMock]:
     """outputs は呼び出し順に返す stdout (str) または raise する例外のリスト"""
     iterator = iter(outputs)
 
-    def _run(*args, **kwargs):
+    def _run(*args: Any, **kwargs: Any) -> MagicMock:
         item = next(iterator)
         if isinstance(item, BaseException):
             raise item
@@ -183,8 +184,8 @@ def _capturer_writing_seq(seq: list[bytes]) -> Callable[[Geometry, Path], None]:
     return _cap
 
 
-def _detect_kwargs(tmp_path: Path, **overrides):
-    base = dict(
+def _detect_kwargs(tmp_path: Path, **overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = dict(
         out_dir=tmp_path,
         geom_provider=lambda: Geometry(0, 0, 100, 100),
         activator=lambda: None,


### PR DESCRIPTION
## Summary

残り 4 ファイルのテストヘルパーに型注釈を追加して `uv run mypy tests/` を **0 errors** にする。Issue #11 を完了。

### 変更内容

#### `tests/unit/test_capture.py`
- import に `collections.abc.Callable` と `typing.Any` を追加
- `_stub_screencapture_factory(...) -> Callable[..., None]` に戻り値型
- 内部 `side_effect(cmd: list[str], **kwargs: Any) -> None` に注釈

#### `tests/unit/test_cli.py`
- import に `collections.abc.Callable` を追加
- `_make_app(func: Callable[..., None]) -> typer.Typer`

#### `tests/unit/test_pdf.py`
- import に `typing.Any` を追加
- `captured_kwargs: dict[str, Any] = {}`
- 内部 `spy(*args: Any, **kwargs: Any) -> Any` に注釈

#### `tests/unit/test_preflight.py`
- import に `typing.Any` を追加
- `_run_factory(outputs: list[str | BaseException]) -> Callable[..., MagicMock]`
- 内部 `_run(*args: Any, **kwargs: Any) -> MagicMock`
- `_detect_kwargs(**overrides: Any) -> dict[str, Any]`、`base: dict[str, Any]`

ロジック変更なし。

## 効果

`uv run mypy tests/` のエラー件数: **10 errors → 0 errors** ✅

PR-B〜E 全体の累積:

| 段階 | 件数 | 主に解消したカテゴリ |
|---|---|---|
| 開始時 | 90 | (PR-A 後 main) |
| PR-B 後 | 73 | `[import-untyped]` 14 + `[unused-ignore]` 2 + `[func-returns-value]` 1 |
| PR-C 後 | 35 | `[no-untyped-def]` 約 30 + `[arg-type]` 6 |
| PR-D 後 | 10 | `[no-untyped-call]` 22 + `[no-untyped-def]` 1 + `[comparison-overlap]` 2 |
| **PR-E 後** | **0** | `[no-untyped-def]` 残り + `[type-arg]` 2 |

## Issue #11 受け入れ条件

- [x] `uv run mypy tests/` が 0 errors
- [x] `uv run pytest tests/unit/ -q` が 258 passed (issue 本文の 154 は公開時の数字で、book_ocr 等の追加で stale。実測 258 を維持基準として更新)
- [ ] CI green ← `gh pr checks` で確認

## 副次的検証

- `uv run mypy src/` → Success (デグレなし)
- `uv run pytest tests/integration/ -q` → 1 passed, 16 skipped (live marker の通常スキップ状態)
- `uv run ruff check src/ tests/` → All checks passed
- `uv run ruff format --check src/ tests/` → 46 files already formatted

## Closes

Closes #11