### PR TITLE
feat(book-ocr): --timeout-sec CLI option (closes #37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `book_ocr.engines.yomitoku.YomiTokuEngine.timeout_sec`（デフォルト 1800 秒）：yomitoku がハングしたときに `RuntimeError` で抜けるための上限時間
 - `book_ocr.cli.run_ocr_pipeline(book_dir, ..., engine=...)`：CLI から分離した OCR パイプライン公開関数。テストや組み込み利用で `engine` を注入できる
 - `book_ocr.engines.yomitoku.YomiTokuEngine.chunk_size` および `book-ocr --chunk-size N` CLI オプション：ページを N 枚ずつ分割して **複数 subprocess で順次 OCR**。巨大本での timeout 回避と、batch size 増大に伴う per-page 時間悪化（10p: 13s/p → 50p: 19s/p の実測差）を回避する。`None`（デフォルト）は従来通り全 PNG を 1 subprocess に渡す（issue #36）
+- `book-ocr --timeout-sec N` CLI オプション：yomitoku subprocess 1 回の timeout を秒単位で指定（デフォルト 1800.0）。chunked 実行時は 1 chunk あたりの上限。巨大本で延長が必要なケースに対応（issue #37）
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ output/my-book.pdf                # 既存。視覚確認用
 | `--ignore-meta / --no-ignore-meta` | `--ignore-meta` | Kindle のヘッダー/フッターを除外 |
 | `--out PATH` | `<book_dir>` | 出力先（省略時は book_dir に書き戻す） |
 | `--chunk-size N` | None | ページを N 枚ずつ分割して OCR (issue #36)。巨大本で timeout 回避＆スケール改善 |
+| `--timeout-sec N` | `1800.0` | yomitoku subprocess 1 回の timeout (秒、issue #37)。chunked 実行時は 1 chunk あたり |
 
 #### 性能の目安（Apple Silicon MPS）
 

--- a/src/book_ocr/cli.py
+++ b/src/book_ocr/cli.py
@@ -22,6 +22,7 @@ def run_ocr_pipeline(
     out: Path | None = None,
     engine: OCREngine | None = None,
     chunk_size: int | None = None,
+    timeout_sec: float = 1800.0,
 ) -> Path:
     """指定した book_dir 内の page_*.png を OCR して Markdown / index.json を出力する.
 
@@ -42,6 +43,7 @@ def run_ocr_pipeline(
         reading_order=reading_order,
         ignore_meta=ignore_meta,
         chunk_size=chunk_size,
+        timeout_sec=timeout_sec,
     )
     meta = BookMetadata(
         title=title,
@@ -93,6 +95,14 @@ def ocr(
             "巨大本で timeout 回避と線形スケール改善。省略時は全 PNG を 1 subprocess。"
         ),
     ),
+    timeout_sec: float = typer.Option(
+        1800.0,
+        "--timeout-sec",
+        help=(
+            "yomitoku subprocess 1 回の timeout (秒、issue #37)。"
+            "chunked 実行時は 1 chunk あたりの上限。巨大本では延長を検討。"
+        ),
+    ),
 ) -> None:
     """指定した book_dir 内の page_*.png を OCR して Markdown / index.json を生成する."""
     try:
@@ -104,6 +114,7 @@ def ocr(
             ignore_meta=ignore_meta,
             out=out,
             chunk_size=chunk_size,
+            timeout_sec=timeout_sec,
         )
     except FileNotFoundError as e:
         typer.echo(str(e), err=True)

--- a/tests/unit/test_book_ocr_cli.py
+++ b/tests/unit/test_book_ocr_cli.py
@@ -145,3 +145,46 @@ class TestChunkSizeOption:
         result = runner.invoke(app, [str(empty), "--chunk-size", "50"])
         assert result.exit_code != 0
         assert "No page_*.png" in result.stdout or "No page_*.png" in (result.stderr or "")
+
+
+class TestTimeoutSecOption:
+    """--timeout-sec CLI フラグが YomiTokuEngine に伝搬すること (issue #37)."""
+
+    @patch("book_ocr.cli.YomiTokuEngine")
+    def test_timeout_sec_propagates_to_engine(
+        self, mock_engine_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_engine = MagicMock()
+        mock_engine.run_batch.return_value = []
+        mock_engine.name = "yomitoku"
+        mock_engine_cls.return_value = mock_engine
+        book = _make_book_dir(tmp_path, n_pages=1)
+
+        run_ocr_pipeline(book_dir=book, timeout_sec=7200.0)
+
+        kwargs = mock_engine_cls.call_args.kwargs
+        assert kwargs["timeout_sec"] == 7200.0
+
+    @patch("book_ocr.cli.YomiTokuEngine")
+    def test_timeout_sec_default_is_1800(self, mock_engine_cls: MagicMock, tmp_path: Path) -> None:
+        mock_engine = MagicMock()
+        mock_engine.run_batch.return_value = []
+        mock_engine.name = "yomitoku"
+        mock_engine_cls.return_value = mock_engine
+        book = _make_book_dir(tmp_path, n_pages=1)
+
+        run_ocr_pipeline(book_dir=book)
+
+        kwargs = mock_engine_cls.call_args.kwargs
+        assert kwargs["timeout_sec"] == 1800.0
+
+    def test_cli_timeout_sec_flag_parses(self, tmp_path: Path) -> None:
+        """--timeout-sec N が CLI から typer.Option で受け取れること (smoke)。"""
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        app = typer.Typer()
+        app.command()(cli.ocr)
+        runner = CliRunner()
+        result = runner.invoke(app, [str(empty), "--timeout-sec", "3600"])
+        assert result.exit_code != 0
+        assert "No page_*.png" in result.stdout or "No page_*.png" in (result.stderr or "")


### PR DESCRIPTION
## Summary

\`book-ocr --timeout-sec N\` を追加。\`YomiTokuEngine.timeout_sec\` (default 1800.0) は実装済みだが CLI から変更不能だった問題を解消。

巨大本検証で確認したように、デフォルト 30 分では 200+ ページの OCR は失敗確実 (Phase C で実証)。\`--chunk-size\` と組み合わせて 1 chunk あたりの上限を調整できる。

## Test plan

- [x] CLI から \`--timeout-sec 7200\` で engine kwargs に伝搬する unit test
- [x] default が 1800.0 のまま保たれる unit test
- [x] CLI flag parse の smoke test
- [x] 273 passed (+3) / mypy clean / ruff format & check passed