### PR TITLE
feat(book-ocr): index.json に再現性メタを追加 (closes #40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 - `book_ocr.cli.run_ocr_pipeline(book_dir, ..., engine=...)`：CLI から分離した OCR パイプライン公開関数。テストや組み込み利用で `engine` を注入できる
 - `book_ocr.engines.yomitoku.YomiTokuEngine.chunk_size` および `book-ocr --chunk-size N` CLI オプション：ページを N 枚ずつ分割して **複数 subprocess で順次 OCR**。巨大本での timeout 回避と、batch size 増大に伴う per-page 時間悪化（10p: 13s/p → 50p: 19s/p の実測差）を回避する。`None`（デフォルト）は従来通り全 PNG を 1 subprocess に渡す（issue #36）
 - `book-ocr --timeout-sec N` CLI オプション：yomitoku subprocess 1 回の timeout を秒単位で指定（デフォルト 1800.0）。chunked 実行時は 1 chunk あたりの上限。巨大本で延長が必要なケースに対応（issue #37）
+- `index.json` に再現性・トラブルシュート用メタを additive に追加（issue #40）：
+  - `ocr_engine_version`：実行時の yomitoku バージョン（`importlib.metadata` 由来、未取得時は `"unknown"`）
+  - `ocr_settings`：`device`, `reading_order`, `ignore_meta`, `chunk_size`, `timeout_sec` の設定値
+  - `ocr_runtime`：`started_at`, `finished_at`, `duration_sec`（`time.perf_counter()` 由来）
+- `OCREngine` Protocol に `version: str` と `settings: dict[str, Any]` プロパティを追加（issue #40）
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ uv run book-ocr output/my-book/
 ```text
 output/my-book/
   page_001.png ...                # 既存（キャプチャ時）
-  index.json                      # 新規。{title, page_count, captured_at, ocr_engine, pages}
+  index.json                      # 新規。{title, page_count, captured_at, ocr_engine, ocr_engine_version, ocr_settings, ocr_runtime, pages}
   my-book.md                      # 新規。全文連結（<!-- page:NNN --> 区切り）— grep 一発用
   pages/
     page_001.md ...               # 新規。ページ単位 Markdown

--- a/src/book_ocr/cli.py
+++ b/src/book_ocr/cli.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -9,6 +11,7 @@ import typer
 
 from book_ocr import orchestrator, writer
 from book_ocr.engines.yomitoku import YomiTokuEngine
+from book_ocr.exporters.json_index import render_index
 from book_ocr.models import BookMetadata
 from book_ocr.protocols import OCREngine
 
@@ -45,15 +48,31 @@ def run_ocr_pipeline(
         chunk_size=chunk_size,
         timeout_sec=timeout_sec,
     )
-    meta = BookMetadata(
+    captured_at = datetime.now(UTC)
+    initial_meta = BookMetadata(
         title=title,
         page_count=len(pngs),
-        captured_at=datetime.now(UTC),
+        captured_at=captured_at,
         ocr_engine=engine.name,
         output_dir=out_dir,
+        ocr_engine_version=engine.version,
+        ocr_settings=engine.settings,
     )
 
-    pages, index_dict, book_md_str = orchestrator.run(engine, meta, pngs)
+    t0 = time.perf_counter()
+    pages, _index_dict_pre, book_md_str = orchestrator.run(engine, initial_meta, pngs)
+    duration_sec = time.perf_counter() - t0
+    finished_at = datetime.now(UTC)
+
+    meta = replace(
+        initial_meta,
+        ocr_runtime={
+            "started_at": captured_at.isoformat(),
+            "finished_at": finished_at.isoformat(),
+            "duration_sec": round(duration_sec, 3),
+        },
+    )
+    index_dict = render_index(meta, pages)
     writer.write_outputs(
         out_dir=out_dir,
         book_md_filename=f"{title}.md",

--- a/src/book_ocr/engines/yomitoku.py
+++ b/src/book_ocr/engines/yomitoku.py
@@ -12,11 +12,13 @@
 
 from __future__ import annotations
 
+import importlib.metadata
 import shutil
 import subprocess
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from book_ocr.models import PageText
 
@@ -42,6 +44,27 @@ class YomiTokuEngine:
     @property
     def name(self) -> str:
         return "yomitoku"
+
+    @property
+    def version(self) -> str:
+        """インストールされた yomitoku のバージョン (issue #40)。
+
+        未インストール / 取得失敗時は `"unknown"` を返す。"""
+        try:
+            return importlib.metadata.version("yomitoku")
+        except importlib.metadata.PackageNotFoundError:
+            return "unknown"
+
+    @property
+    def settings(self) -> dict[str, Any]:
+        """index.json に記録する OCR 設定 (issue #40)。"""
+        return {
+            "device": self.device,
+            "reading_order": self.reading_order,
+            "ignore_meta": self.ignore_meta,
+            "chunk_size": self.chunk_size,
+            "timeout_sec": self.timeout_sec,
+        }
 
     def run_batch(self, pngs: list[Path]) -> list[PageText]:
         if not pngs:

--- a/src/book_ocr/exporters/json_index.py
+++ b/src/book_ocr/exporters/json_index.py
@@ -13,18 +13,28 @@ def render_index(meta: BookMetadata, pages: list[PageText]) -> dict[str, Any]:
     `png` フィールドはファイル名のみ (例 "page_001.png")。kindle-cap の出力規約上、
     PNG は単一ディレクトリに並ぶので、ディレクトリ構造を保持する必要がない。
     book_dir != output_dir (--out 指定時) でも relative_to の ValueError を踏まない。
+
+    issue #40: `ocr_engine_version` / `ocr_settings` / `ocr_runtime` が
+    `BookMetadata` に設定されていれば additive に追記する (None なら省略)。
     """
-    return {
+    result: dict[str, Any] = {
         "title": meta.title,
         "page_count": meta.page_count,
         "captured_at": meta.captured_at.isoformat(),
         "ocr_engine": meta.ocr_engine,
-        "pages": [
-            {
-                "n": p.page_number,
-                "png": p.png_path.name,
-                "md": f"pages/page_{p.page_number:03d}.md",
-            }
-            for p in pages
-        ],
     }
+    if meta.ocr_engine_version is not None:
+        result["ocr_engine_version"] = meta.ocr_engine_version
+    if meta.ocr_settings is not None:
+        result["ocr_settings"] = meta.ocr_settings
+    if meta.ocr_runtime is not None:
+        result["ocr_runtime"] = meta.ocr_runtime
+    result["pages"] = [
+        {
+            "n": p.page_number,
+            "png": p.png_path.name,
+            "md": f"pages/page_{p.page_number:03d}.md",
+        }
+        for p in pages
+    ]
+    return result

--- a/src/book_ocr/models.py
+++ b/src/book_ocr/models.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -28,6 +29,10 @@ class BookMetadata:
     captured_at: datetime
     ocr_engine: str
     output_dir: Path
+    # issue #40: 再現性 / トラブルシュート用の追加メタ。optional で後方互換維持
+    ocr_engine_version: str | None = None
+    ocr_settings: dict[str, Any] | None = field(default=None)
+    ocr_runtime: dict[str, Any] | None = field(default=None)
 
     def __post_init__(self) -> None:
         if not self.title:

--- a/src/book_ocr/protocols.py
+++ b/src/book_ocr/protocols.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol
 
 from book_ocr.models import PageText
 
@@ -11,5 +11,11 @@ from book_ocr.models import PageText
 class OCREngine(Protocol):
     @property
     def name(self) -> str: ...
+
+    @property
+    def version(self) -> str: ...
+
+    @property
+    def settings(self) -> dict[str, Any]: ...
 
     def run_batch(self, pngs: list[Path]) -> list[PageText]: ...

--- a/tests/unit/test_book_ocr_cli.py
+++ b/tests/unit/test_book_ocr_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -19,6 +20,14 @@ class FakeEngine:
     @property
     def name(self) -> str:
         return "fake"
+
+    @property
+    def version(self) -> str:
+        return "0.0.0-fake"
+
+    @property
+    def settings(self) -> dict[str, Any]:
+        return {"engine": "fake"}
 
     def run_batch(self, pngs: list[Path]) -> list[PageText]:
         return [
@@ -113,6 +122,8 @@ class TestChunkSizeOption:
         mock_engine = MagicMock()
         mock_engine.run_batch.return_value = []
         mock_engine.name = "yomitoku"
+        mock_engine.version = "0.12.0"
+        mock_engine.settings = {"device": "mps"}
         mock_engine_cls.return_value = mock_engine
         book = _make_book_dir(tmp_path, n_pages=1)
 
@@ -126,6 +137,8 @@ class TestChunkSizeOption:
         mock_engine = MagicMock()
         mock_engine.run_batch.return_value = []
         mock_engine.name = "yomitoku"
+        mock_engine.version = "0.12.0"
+        mock_engine.settings = {"device": "mps"}
         mock_engine_cls.return_value = mock_engine
         book = _make_book_dir(tmp_path, n_pages=1)
 
@@ -157,6 +170,8 @@ class TestTimeoutSecOption:
         mock_engine = MagicMock()
         mock_engine.run_batch.return_value = []
         mock_engine.name = "yomitoku"
+        mock_engine.version = "0.12.0"
+        mock_engine.settings = {"device": "mps"}
         mock_engine_cls.return_value = mock_engine
         book = _make_book_dir(tmp_path, n_pages=1)
 
@@ -170,6 +185,8 @@ class TestTimeoutSecOption:
         mock_engine = MagicMock()
         mock_engine.run_batch.return_value = []
         mock_engine.name = "yomitoku"
+        mock_engine.version = "0.12.0"
+        mock_engine.settings = {"device": "mps"}
         mock_engine_cls.return_value = mock_engine
         book = _make_book_dir(tmp_path, n_pages=1)
 
@@ -188,3 +205,40 @@ class TestTimeoutSecOption:
         result = runner.invoke(app, [str(empty), "--timeout-sec", "3600"])
         assert result.exit_code != 0
         assert "No page_*.png" in result.stdout or "No page_*.png" in (result.stderr or "")
+
+
+class TestIndexMetadataExtension:
+    """issue #40: index.json に reproducibility メタが書き込まれること。"""
+
+    def test_index_json_contains_engine_version(self, tmp_path: Path) -> None:
+        book = _make_book_dir(tmp_path, n_pages=1)
+        run_ocr_pipeline(book_dir=book, engine=FakeEngine())
+
+        data = json.loads((book / "index.json").read_text(encoding="utf-8"))
+        assert data["ocr_engine_version"] == "0.0.0-fake"
+
+    def test_index_json_contains_ocr_settings(self, tmp_path: Path) -> None:
+        book = _make_book_dir(tmp_path, n_pages=1)
+        run_ocr_pipeline(book_dir=book, engine=FakeEngine())
+
+        data = json.loads((book / "index.json").read_text(encoding="utf-8"))
+        assert data["ocr_settings"] == {"engine": "fake"}
+
+    def test_index_json_contains_ocr_runtime_with_duration(self, tmp_path: Path) -> None:
+        book = _make_book_dir(tmp_path, n_pages=1)
+        run_ocr_pipeline(book_dir=book, engine=FakeEngine())
+
+        data = json.loads((book / "index.json").read_text(encoding="utf-8"))
+        runtime = data["ocr_runtime"]
+        assert "started_at" in runtime
+        assert "finished_at" in runtime
+        assert isinstance(runtime["duration_sec"], int | float)
+        assert runtime["duration_sec"] >= 0
+
+    def test_index_json_runtime_started_before_finished(self, tmp_path: Path) -> None:
+        book = _make_book_dir(tmp_path, n_pages=1)
+        run_ocr_pipeline(book_dir=book, engine=FakeEngine())
+
+        data = json.loads((book / "index.json").read_text(encoding="utf-8"))
+        runtime = data["ocr_runtime"]
+        assert runtime["started_at"] <= runtime["finished_at"]

--- a/tests/unit/test_book_ocr_exporters.py
+++ b/tests/unit/test_book_ocr_exporters.py
@@ -128,3 +128,79 @@ class TestRenderIndex:
         )
         result = render_index(meta, [page])
         assert result["pages"][0]["png"] == "page_001.png"
+
+
+class TestRenderIndexOptionalMetadata:
+    """issue #40: optional な reproducibility メタを additive に出力する."""
+
+    def test_omits_optional_fields_when_none(self, make_meta: Callable[..., BookMetadata]) -> None:
+        meta = make_meta()  # default は全 None
+        result = render_index(meta, [])
+        assert "ocr_engine_version" not in result
+        assert "ocr_settings" not in result
+        assert "ocr_runtime" not in result
+
+    def test_emits_engine_version_when_set(self) -> None:
+        meta = BookMetadata(
+            title="my-book",
+            page_count=0,
+            captured_at=datetime(2026, 4, 28, 21, 0, 0, tzinfo=UTC),
+            ocr_engine="yomitoku",
+            output_dir=Path("/tmp"),
+            ocr_engine_version="0.12.0",
+        )
+        result = render_index(meta, [])
+        assert result["ocr_engine_version"] == "0.12.0"
+
+    def test_emits_settings_dict_when_set(self) -> None:
+        meta = BookMetadata(
+            title="my-book",
+            page_count=0,
+            captured_at=datetime(2026, 4, 28, 21, 0, 0, tzinfo=UTC),
+            ocr_engine="yomitoku",
+            output_dir=Path("/tmp"),
+            ocr_settings={"device": "mps", "reading_order": "auto", "ignore_meta": True},
+        )
+        result = render_index(meta, [])
+        assert result["ocr_settings"] == {
+            "device": "mps",
+            "reading_order": "auto",
+            "ignore_meta": True,
+        }
+
+    def test_emits_runtime_dict_when_set(self) -> None:
+        meta = BookMetadata(
+            title="my-book",
+            page_count=0,
+            captured_at=datetime(2026, 4, 28, 21, 0, 0, tzinfo=UTC),
+            ocr_engine="yomitoku",
+            output_dir=Path("/tmp"),
+            ocr_runtime={
+                "started_at": "2026-04-28T21:00:00+00:00",
+                "finished_at": "2026-04-28T21:02:00+00:00",
+                "duration_sec": 120.0,
+            },
+        )
+        result = render_index(meta, [])
+        assert result["ocr_runtime"]["duration_sec"] == 120.0
+        assert result["ocr_runtime"]["started_at"] == "2026-04-28T21:00:00+00:00"
+
+    def test_existing_top_level_fields_unchanged_when_optional_set(
+        self, make_meta: Callable[..., BookMetadata]
+    ) -> None:
+        """新フィールド追加で既存フィールドが消えないこと (additive guarantee)。"""
+        from dataclasses import replace
+
+        meta = make_meta()
+        meta_with_extras = replace(
+            meta,
+            ocr_engine_version="0.12.0",
+            ocr_settings={"device": "mps"},
+            ocr_runtime={"duration_sec": 1.0},
+        )
+        result = render_index(meta_with_extras, [])
+        assert result["title"] == "my-book"
+        assert result["page_count"] == 2
+        assert result["ocr_engine"] == "yomitoku"
+        assert "captured_at" in result
+        assert "pages" in result

--- a/tests/unit/test_book_ocr_models.py
+++ b/tests/unit/test_book_ocr_models.py
@@ -124,3 +124,34 @@ class TestBookMetadata:
                 ocr_engine="",
                 output_dir=Path("/tmp"),
             )
+
+    # -----------------------------------------------------------------------
+    # issue #40: optional reproducibility metadata
+    # -----------------------------------------------------------------------
+
+    def test_optional_metadata_defaults_to_none(self) -> None:
+        meta = BookMetadata(
+            title="my-book",
+            page_count=1,
+            captured_at=datetime(2026, 4, 28, tzinfo=UTC),
+            ocr_engine="yomitoku",
+            output_dir=Path("/tmp"),
+        )
+        assert meta.ocr_engine_version is None
+        assert meta.ocr_settings is None
+        assert meta.ocr_runtime is None
+
+    def test_optional_metadata_accepts_values(self) -> None:
+        meta = BookMetadata(
+            title="my-book",
+            page_count=1,
+            captured_at=datetime(2026, 4, 28, tzinfo=UTC),
+            ocr_engine="yomitoku",
+            output_dir=Path("/tmp"),
+            ocr_engine_version="0.12.0",
+            ocr_settings={"device": "mps", "reading_order": "auto"},
+            ocr_runtime={"duration_sec": 12.5},
+        )
+        assert meta.ocr_engine_version == "0.12.0"
+        assert meta.ocr_settings == {"device": "mps", "reading_order": "auto"}
+        assert meta.ocr_runtime == {"duration_sec": 12.5}

--- a/tests/unit/test_book_ocr_orchestrator.py
+++ b/tests/unit/test_book_ocr_orchestrator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -20,6 +21,14 @@ class FakeEngine:
     @property
     def name(self) -> str:
         return "fake"
+
+    @property
+    def version(self) -> str:
+        return "0.0.0-fake"
+
+    @property
+    def settings(self) -> dict[str, Any]:
+        return {"engine": "fake"}
 
     def _one(self, png: Path) -> PageText:
         n = int(png.stem.split("_")[-1])  # page_001.png -> 1
@@ -133,6 +142,14 @@ class TestOrchestratorRun:
             def name(self) -> str:
                 return "fake"
 
+            @property
+            def version(self) -> str:
+                return "0.0.0-fake"
+
+            @property
+            def settings(self) -> dict[str, Any]:
+                return {}
+
             def run_batch(self, pngs: list[Path]) -> list[PageText]:
                 nonlocal call_count
                 call_count += 1
@@ -167,6 +184,14 @@ class TestOrchestratorRunInputValidation:
             @property
             def name(self) -> str:
                 return "broken"
+
+            @property
+            def version(self) -> str:
+                return "0.0.0-broken"
+
+            @property
+            def settings(self) -> dict[str, Any]:
+                return {}
 
             def run_batch(self, pngs: list[Path]) -> list[PageText]:
                 # png のファイル名に関わらず常に page_number=1 を返す


### PR DESCRIPTION
## Summary

実書籍検証で「OCR 結果がおかしい」報告時に原因特定が困難な点を解消。\`index.json\` に additive に以下を追加:

- \`ocr_engine_version\`: \`importlib.metadata.version("yomitoku")\` 由来 (今回 \"0.12.0\")
- \`ocr_settings\`: \`device\`, \`reading_order\`, \`ignore_meta\`, \`chunk_size\`, \`timeout_sec\`
- \`ocr_runtime\`: \`started_at\`, \`finished_at\`, \`duration_sec\` (\`time.perf_counter()\` 由来)

\`OCREngine\` Protocol に \`version\` / \`settings\` プロパティを追加。FakeEngine / BrokenEngine / CountingFakeEngine を更新。

## Test plan

- [x] 既存 schema 維持を確認するテスト (\`test_optional_metadata_defaults_to_none\` 等)
- [x] 各 optional フィールドの emit テスト
- [x] CLI 経由で \`index.json\` に runtime + settings + version が書き込まれること
- [x] 284 passed (+11) / mypy clean / ruff format & check passed
- [x] **実 OCR 動作検証**: 1 ページで生成された \`index.json\` を確認
\`\`\`json
{
  "ocr_engine_version": "0.12.0",
  "ocr_settings": {"device": "mps", "reading_order": "auto", "ignore_meta": true, "chunk_size": null, "timeout_sec": 1800.0},
  "ocr_runtime": {"started_at": "...", "finished_at": "...", "duration_sec": 34.727}
}
\`\`\`

## Breaking Change Note

\`OCREngine\` Protocol に \`version\` / \`settings\` を追加。既存 implementation (FakeEngine 等のテスト用) は対応済み。下流に他 engine 実装がある場合は要更新。