### PR TITLE
feat(book-ocr): --start-page / --end-page で範囲指定 (closes #39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - `ocr_settings`：`device`, `reading_order`, `ignore_meta`, `chunk_size`, `timeout_sec` の設定値
   - `ocr_runtime`：`started_at`, `finished_at`, `duration_sec`（`time.perf_counter()` 由来）
 - `OCREngine` Protocol に `version: str` と `settings: dict[str, Any]` プロパティを追加（issue #40）
+- `book-ocr --start-page N` / `--end-page M` CLI オプション：1-indexed inclusive で OCR 対象範囲を絞れる。失敗後の局所再走 (chunked 実行と組み合わせた retry や、巨大本の段階的処理) に有効（issue #39）
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ output/my-book.pdf                # 既存。視覚確認用
 | `--out PATH` | `<book_dir>` | 出力先（省略時は book_dir に書き戻す） |
 | `--chunk-size N` | None | ページを N 枚ずつ分割して OCR (issue #36)。巨大本で timeout 回避＆スケール改善 |
 | `--timeout-sec N` | `1800.0` | yomitoku subprocess 1 回の timeout (秒、issue #37)。chunked 実行時は 1 chunk あたり |
+| `--start-page N` | `1` | OCR 開始ページ番号 (1-indexed inclusive、issue #39) |
+| `--end-page M` | None | OCR 終了ページ番号 (1-indexed inclusive、省略時は最後まで、issue #39) |
 
 #### 性能の目安（Apple Silicon MPS）
 

--- a/src/book_ocr/cli.py
+++ b/src/book_ocr/cli.py
@@ -26,17 +26,31 @@ def run_ocr_pipeline(
     engine: OCREngine | None = None,
     chunk_size: int | None = None,
     timeout_sec: float = 1800.0,
+    start_page: int = 1,
+    end_page: int | None = None,
 ) -> Path:
     """指定した book_dir 内の page_*.png を OCR して Markdown / index.json を出力する.
 
     `engine=None` のときは `YomiTokuEngine` を生成する。テストでは FakeEngine 等を渡す。
 
+    `start_page` / `end_page` (1-indexed inclusive) で対象範囲を絞れる (issue #39)。
+    ファイル名 `page_NNN.png` の NNN 部分でフィルタする。
+
     Returns:
         生成された book Markdown ファイルのパス。
     """
-    pngs = sorted(book_dir.glob("page_*.png"))
+    if start_page < 1:
+        raise ValueError(f"start_page must be >= 1, got {start_page}")
+    if end_page is not None and end_page < start_page:
+        raise ValueError(f"end_page ({end_page}) must be >= start_page ({start_page})")
+
+    all_pngs = sorted(book_dir.glob("page_*.png"))
+    pngs = [p for p in all_pngs if start_page <= _parse_page_number(p) <= (end_page or 10**9)]
     if not pngs:
-        raise FileNotFoundError(f"No page_*.png in {book_dir}")
+        raise FileNotFoundError(
+            f"No page_*.png in {book_dir} for range "
+            f"[{start_page}, {end_page if end_page is not None else 'end'}]"
+        )
 
     title = name or book_dir.name
     out_dir = out or book_dir
@@ -122,6 +136,16 @@ def ocr(
             "chunked 実行時は 1 chunk あたりの上限。巨大本では延長を検討。"
         ),
     ),
+    start_page: int = typer.Option(
+        1,
+        "--start-page",
+        help="OCR 開始ページ番号 (1-indexed inclusive、issue #39)。",
+    ),
+    end_page: int | None = typer.Option(
+        None,
+        "--end-page",
+        help="OCR 終了ページ番号 (1-indexed inclusive、省略時は最後まで、issue #39)。",
+    ),
 ) -> None:
     """指定した book_dir 内の page_*.png を OCR して Markdown / index.json を生成する."""
     try:
@@ -134,11 +158,21 @@ def ocr(
             out=out,
             chunk_size=chunk_size,
             timeout_sec=timeout_sec,
+            start_page=start_page,
+            end_page=end_page,
         )
     except FileNotFoundError as e:
         typer.echo(str(e), err=True)
         raise typer.Exit(1) from e
+    except ValueError as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(1) from e
     typer.echo(f"OCR complete: {out_path}")
+
+
+def _parse_page_number(p: Path) -> int:
+    """`page_NNN.png` から NNN を取り出す。issue #39 の範囲フィルタで使う。"""
+    return int(p.stem.split("_")[-1])
 
 
 def run_ocr() -> None:

--- a/tests/unit/test_book_ocr_cli.py
+++ b/tests/unit/test_book_ocr_cli.py
@@ -207,6 +207,87 @@ class TestTimeoutSecOption:
         assert "No page_*.png" in result.stdout or "No page_*.png" in (result.stderr or "")
 
 
+class TestPageRangeOption:
+    """issue #39: --start-page / --end-page で範囲指定。"""
+
+    def test_start_page_skips_earlier_pages(self, tmp_path: Path) -> None:
+        book = _make_book_dir(tmp_path, n_pages=5)
+        run_ocr_pipeline(book_dir=book, engine=FakeEngine(), start_page=3)
+
+        # page_003 〜 page_005 のみが OCR される
+        assert (book / "pages" / "page_003.md").exists()
+        assert (book / "pages" / "page_004.md").exists()
+        assert (book / "pages" / "page_005.md").exists()
+        assert not (book / "pages" / "page_001.md").exists()
+        assert not (book / "pages" / "page_002.md").exists()
+
+    def test_end_page_truncates_to_upper_bound(self, tmp_path: Path) -> None:
+        book = _make_book_dir(tmp_path, n_pages=5)
+        run_ocr_pipeline(book_dir=book, engine=FakeEngine(), end_page=2)
+
+        assert (book / "pages" / "page_001.md").exists()
+        assert (book / "pages" / "page_002.md").exists()
+        assert not (book / "pages" / "page_003.md").exists()
+
+    def test_both_start_and_end_pages(self, tmp_path: Path) -> None:
+        book = _make_book_dir(tmp_path, n_pages=5)
+        run_ocr_pipeline(book_dir=book, engine=FakeEngine(), start_page=2, end_page=4)
+
+        assert not (book / "pages" / "page_001.md").exists()
+        assert (book / "pages" / "page_002.md").exists()
+        assert (book / "pages" / "page_003.md").exists()
+        assert (book / "pages" / "page_004.md").exists()
+        assert not (book / "pages" / "page_005.md").exists()
+
+    def test_start_page_inclusive(self, tmp_path: Path) -> None:
+        """start_page=N を指定すると、ちょうど page_N が含まれる (inclusive)。"""
+        book = _make_book_dir(tmp_path, n_pages=3)
+        run_ocr_pipeline(book_dir=book, engine=FakeEngine(), start_page=2)
+
+        assert (book / "pages" / "page_002.md").exists()
+        assert (book / "pages" / "page_003.md").exists()
+
+    def test_end_page_inclusive(self, tmp_path: Path) -> None:
+        """end_page=N を指定すると、page_N も含まれる (inclusive)。"""
+        book = _make_book_dir(tmp_path, n_pages=3)
+        run_ocr_pipeline(book_dir=book, engine=FakeEngine(), end_page=2)
+
+        assert (book / "pages" / "page_002.md").exists()
+        assert not (book / "pages" / "page_003.md").exists()
+
+    def test_start_page_zero_rejected(self, tmp_path: Path) -> None:
+        book = _make_book_dir(tmp_path, n_pages=3)
+        with pytest.raises(ValueError, match="start_page"):
+            run_ocr_pipeline(book_dir=book, engine=FakeEngine(), start_page=0)
+
+    def test_start_page_greater_than_end_page_rejected(self, tmp_path: Path) -> None:
+        book = _make_book_dir(tmp_path, n_pages=5)
+        with pytest.raises(ValueError, match=r"end_page.*>=.*start_page"):
+            run_ocr_pipeline(book_dir=book, engine=FakeEngine(), start_page=4, end_page=2)
+
+    def test_range_with_no_pages_in_dir_raises(self, tmp_path: Path) -> None:
+        book = _make_book_dir(tmp_path, n_pages=3)
+        with pytest.raises(FileNotFoundError, match="No page_"):
+            run_ocr_pipeline(book_dir=book, engine=FakeEngine(), start_page=10)
+
+    def test_index_page_count_reflects_range(self, tmp_path: Path) -> None:
+        book = _make_book_dir(tmp_path, n_pages=5)
+        run_ocr_pipeline(book_dir=book, engine=FakeEngine(), start_page=2, end_page=4)
+
+        data = json.loads((book / "index.json").read_text(encoding="utf-8"))
+        assert data["page_count"] == 3  # 2,3,4 の 3 ページ
+
+    def test_cli_start_end_page_flags_parse(self, tmp_path: Path) -> None:
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        app = typer.Typer()
+        app.command()(cli.ocr)
+        runner = CliRunner()
+        result = runner.invoke(app, [str(empty), "--start-page", "5", "--end-page", "10"])
+        assert result.exit_code != 0  # No page_*.png なのでエラー終了
+        assert "No page_*.png" in result.stdout or "No page_*.png" in (result.stderr or "")
+
+
 class TestIndexMetadataExtension:
     """issue #40: index.json に reproducibility メタが書き込まれること。"""
 


### PR DESCRIPTION
## Summary

\`book-ocr book/ --start-page N --end-page M\` で OCR 対象を絞れるように。失敗後の局所再走 (chunked 実行と組み合わせて retry) や巨大本の段階的処理に対応。

ファイル名 \`page_NNN.png\` の NNN 部分でフィルタ (1-indexed inclusive)。

## Test plan

- [x] start_page で前半スキップ / end_page で後半切り捨て / 両方の組み合わせ
- [x] inclusive 境界 (start=N で page_N が含まれる)
- [x] バリデーション: start < 1, end < start, 範囲内に PNG なし
- [x] index.json の page_count が範囲後の枚数になる
- [x] CLI フラグ parse smoke
- [x] 294 passed (+10) / mypy clean / ruff format & check passed

## 例

\`\`\`bash
# 100-150 ページだけ OCR (失敗 chunk 再走に有効)
book-ocr output/my-book --start-page 100 --end-page 150

# 200 ページ目以降を OCR
book-ocr output/my-book --start-page 200
\`\`\`