### PR TITLE
feat(book-ocr): tqdm で chunk 進捗を stderr に表示 (closes #38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
   - `ocr_runtime`：`started_at`, `finished_at`, `duration_sec`（`time.perf_counter()` 由来）
 - `OCREngine` Protocol に `version: str` と `settings: dict[str, Any]` プロパティを追加（issue #40）
 - `book-ocr --start-page N` / `--end-page M` CLI オプション：1-indexed inclusive で OCR 対象範囲を絞れる。失敗後の局所再走 (chunked 実行と組み合わせた retry や、巨大本の段階的処理) に有効（issue #39）
+- `book-ocr --progress` / `--no-progress` CLI オプション + `YomiTokuEngine.progress`：chunked 実行時に `tqdm` で chunk 単位の進捗を stderr に表示。chunk 数 < 2 や非 tty 環境では自動的に無効化（issue #38）
+- `tqdm>=4.0` を `[ocr]` extra の依存に追加（yomitoku の transitive dep だが明示化）
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - `OCREngine` Protocol に `version: str` と `settings: dict[str, Any]` プロパティを追加（issue #40）
 - `book-ocr --start-page N` / `--end-page M` CLI オプション：1-indexed inclusive で OCR 対象範囲を絞れる。失敗後の局所再走 (chunked 実行と組み合わせた retry や、巨大本の段階的処理) に有効（issue #39）
 - `book-ocr --progress` / `--no-progress` CLI オプション + `YomiTokuEngine.progress`：chunked 実行時に `tqdm` で chunk 単位の進捗を stderr に表示。chunk 数 < 2 や非 tty 環境では自動的に無効化（issue #38）
-- `tqdm>=4.0` を `[ocr]` extra の依存に追加（yomitoku の transitive dep だが明示化）
+- `tqdm>=4.0` を base 依存に追加（chunked 進捗表示で必要、CI でも常時入手するため `[ocr]` extra ではなく base に置く）
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ output/my-book.pdf                # 既存。視覚確認用
 | `--timeout-sec N` | `1800.0` | yomitoku subprocess 1 回の timeout (秒、issue #37)。chunked 実行時は 1 chunk あたり |
 | `--start-page N` | `1` | OCR 開始ページ番号 (1-indexed inclusive、issue #39) |
 | `--end-page M` | None | OCR 終了ページ番号 (1-indexed inclusive、省略時は最後まで、issue #39) |
+| `--progress / --no-progress` | `--progress` | chunked 実行時に tqdm で chunk 進捗を stderr に表示 (issue #38) |
 
 #### 性能の目安（Apple Silicon MPS）
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,12 +22,12 @@ dependencies = [
     "typer>=0.16",
     "img2pdf>=0.5",
     "pillow>=10.0",
+    "tqdm>=4.0",
 ]
 
 [project.optional-dependencies]
 ocr = [
     "yomitoku>=0.4",
-    "tqdm>=4.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 [project.optional-dependencies]
 ocr = [
     "yomitoku>=0.4",
+    "tqdm>=4.0",
 ]
 
 [project.urls]
@@ -93,6 +94,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["yomitoku", "yomitoku.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["tqdm", "tqdm.*"]
 ignore_missing_imports = true
 
 [build-system]

--- a/src/book_ocr/cli.py
+++ b/src/book_ocr/cli.py
@@ -28,6 +28,7 @@ def run_ocr_pipeline(
     timeout_sec: float = 1800.0,
     start_page: int = 1,
     end_page: int | None = None,
+    progress: bool = True,
 ) -> Path:
     """指定した book_dir 内の page_*.png を OCR して Markdown / index.json を出力する.
 
@@ -61,6 +62,7 @@ def run_ocr_pipeline(
         ignore_meta=ignore_meta,
         chunk_size=chunk_size,
         timeout_sec=timeout_sec,
+        progress=progress,
     )
     captured_at = datetime.now(UTC)
     initial_meta = BookMetadata(
@@ -146,6 +148,14 @@ def ocr(
         "--end-page",
         help="OCR 終了ページ番号 (1-indexed inclusive、省略時は最後まで、issue #39)。",
     ),
+    progress: bool = typer.Option(
+        True,
+        "--progress/--no-progress",
+        help=(
+            "chunked 実行時に tqdm で chunk 単位の進捗を stderr に表示する (issue #38)。"
+            "非 tty 環境では自動的に無効化される。"
+        ),
+    ),
 ) -> None:
     """指定した book_dir 内の page_*.png を OCR して Markdown / index.json を生成する."""
     try:
@@ -160,6 +170,7 @@ def ocr(
             timeout_sec=timeout_sec,
             start_page=start_page,
             end_page=end_page,
+            progress=progress,
         )
     except FileNotFoundError as e:
         typer.echo(str(e), err=True)

--- a/src/book_ocr/engines/yomitoku.py
+++ b/src/book_ocr/engines/yomitoku.py
@@ -8,6 +8,9 @@
 - 各チャンク独立 tempdir で I/O 競合なし
 
 `chunk_size=None` (default) は従来通り全 PNG を 1 subprocess に渡す挙動。
+
+`progress=True` (default) かつ chunk 数 >= 2 のとき、`tqdm` で chunk 単位の進捗を
+stderr に表示する (issue #38)。
 """
 
 from __future__ import annotations
@@ -15,10 +18,14 @@ from __future__ import annotations
 import importlib.metadata
 import shutil
 import subprocess
+import sys
 import tempfile
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+from tqdm import tqdm
 
 from book_ocr.models import PageText
 
@@ -36,6 +43,8 @@ class YomiTokuEngine:
     timeout_sec: float = 1800.0
     # None なら全 PNG を 1 subprocess、int なら chunk_size 単位で分割実行 (issue #36)
     chunk_size: int | None = None
+    # chunked 実行時に tqdm で chunk 進捗を stderr に表示する (issue #38)
+    progress: bool = True
 
     def __post_init__(self) -> None:
         if self.chunk_size is not None and self.chunk_size < 1:
@@ -74,7 +83,8 @@ class YomiTokuEngine:
         chunks = _split_into_chunks(pngs, self.chunk_size)
 
         all_pages: list[PageText] = []
-        for chunk in chunks:
+        chunk_iter: Iterable[list[Path]] = _maybe_tqdm(chunks, enabled=self.progress)
+        for chunk in chunk_iter:
             all_pages.extend(self._run_one_subprocess(binary, chunk))
         return all_pages
 
@@ -141,6 +151,22 @@ def _split_into_chunks(pngs: list[Path], chunk_size: int | None) -> list[list[Pa
     if chunk_size is None or chunk_size >= len(pngs):
         return [pngs]
     return [pngs[i : i + chunk_size] for i in range(0, len(pngs), chunk_size)]
+
+
+def _maybe_tqdm(chunks: list[list[Path]], *, enabled: bool) -> Iterable[list[Path]]:
+    """chunk 数 >= 2 かつ enabled かつ stderr が tty のとき、tqdm でラップする (issue #38)。
+
+    1 chunk のときは進捗バーが意味を持たないため bare iterable を返す。
+    CI など非 tty の場合は disable=True で tqdm を no-op にする。"""
+    if len(chunks) < 2 or not enabled:
+        return chunks
+    wrapped: Iterable[list[Path]] = tqdm(
+        chunks,
+        desc="OCR (chunks)",
+        unit="chunk",
+        disable=not sys.stderr.isatty(),
+    )
+    return wrapped
 
 
 def _ensure_yomitoku_succeeded(returncode: int, stdout: str, stderr: str) -> None:

--- a/tests/unit/test_book_ocr_cli.py
+++ b/tests/unit/test_book_ocr_cli.py
@@ -288,6 +288,50 @@ class TestPageRangeOption:
         assert "No page_*.png" in result.stdout or "No page_*.png" in (result.stderr or "")
 
 
+class TestProgressOption:
+    """issue #38: --progress / --no-progress が YomiTokuEngine に伝搬する。"""
+
+    @patch("book_ocr.cli.YomiTokuEngine")
+    def test_progress_default_is_true(self, mock_engine_cls: MagicMock, tmp_path: Path) -> None:
+        mock_engine = MagicMock()
+        mock_engine.run_batch.return_value = []
+        mock_engine.name = "yomitoku"
+        mock_engine.version = "0.12.0"
+        mock_engine.settings = {"device": "mps"}
+        mock_engine_cls.return_value = mock_engine
+        book = _make_book_dir(tmp_path, n_pages=1)
+
+        run_ocr_pipeline(book_dir=book)
+
+        kwargs = mock_engine_cls.call_args.kwargs
+        assert kwargs["progress"] is True
+
+    @patch("book_ocr.cli.YomiTokuEngine")
+    def test_progress_false_propagates(self, mock_engine_cls: MagicMock, tmp_path: Path) -> None:
+        mock_engine = MagicMock()
+        mock_engine.run_batch.return_value = []
+        mock_engine.name = "yomitoku"
+        mock_engine.version = "0.12.0"
+        mock_engine.settings = {"device": "mps"}
+        mock_engine_cls.return_value = mock_engine
+        book = _make_book_dir(tmp_path, n_pages=1)
+
+        run_ocr_pipeline(book_dir=book, progress=False)
+
+        kwargs = mock_engine_cls.call_args.kwargs
+        assert kwargs["progress"] is False
+
+    def test_cli_no_progress_flag_parses(self, tmp_path: Path) -> None:
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        app = typer.Typer()
+        app.command()(cli.ocr)
+        runner = CliRunner()
+        result = runner.invoke(app, [str(empty), "--no-progress"])
+        assert result.exit_code != 0  # No page_*.png でエラー終了
+        assert "No page_*.png" in result.stdout or "No page_*.png" in (result.stderr or "")
+
+
 class TestIndexMetadataExtension:
     """issue #40: index.json に reproducibility メタが書き込まれること。"""
 

--- a/tests/unit/test_book_ocr_engine.py
+++ b/tests/unit/test_book_ocr_engine.py
@@ -204,3 +204,69 @@ def test_chunked_execution_propagates_mid_chunk_failure(
     with pytest.raises(RuntimeError, match="timeout"):
         engine.run_batch(pngs)
     assert mock_run.call_count == 2  # 1 success + 1 fail
+
+
+# ---------------------------------------------------------------------------
+# tqdm progress display (issue #38)
+# ---------------------------------------------------------------------------
+
+
+@patch("book_ocr.engines.yomitoku.tqdm")
+@patch("book_ocr.engines.yomitoku.subprocess.run", side_effect=_fake_yomitoku_subprocess)
+def test_tqdm_called_when_progress_true_and_chunked(
+    mock_run: MagicMock, mock_tqdm: MagicMock, tmp_path: Path
+) -> None:
+    """chunk 数 >= 2 かつ progress=True で tqdm を呼ぶ。"""
+    mock_tqdm.side_effect = lambda chunks, **kwargs: list(chunks)
+    pngs = _make_pngs(tmp_path, 5)
+    engine = YomiTokuEngine(yomitoku_bin=_fake_binary(tmp_path), chunk_size=2, progress=True)
+
+    engine.run_batch(pngs)
+
+    assert mock_tqdm.call_count == 1
+
+
+@patch("book_ocr.engines.yomitoku.tqdm")
+@patch("book_ocr.engines.yomitoku.subprocess.run", side_effect=_fake_yomitoku_subprocess)
+def test_tqdm_not_called_when_progress_false(
+    mock_run: MagicMock, mock_tqdm: MagicMock, tmp_path: Path
+) -> None:
+    """progress=False のとき tqdm を呼ばない。"""
+    pngs = _make_pngs(tmp_path, 5)
+    engine = YomiTokuEngine(yomitoku_bin=_fake_binary(tmp_path), chunk_size=2, progress=False)
+
+    engine.run_batch(pngs)
+
+    assert mock_tqdm.call_count == 0
+
+
+@patch("book_ocr.engines.yomitoku.tqdm")
+@patch("book_ocr.engines.yomitoku.subprocess.run", side_effect=_fake_yomitoku_subprocess)
+def test_tqdm_not_called_when_only_one_chunk(
+    mock_run: MagicMock, mock_tqdm: MagicMock, tmp_path: Path
+) -> None:
+    """chunk 数 == 1 のとき tqdm を呼ばない (進捗バーが意味を持たない)。"""
+    pngs = _make_pngs(tmp_path, 3)
+    # chunk_size 未指定 → 1 chunk
+    engine = YomiTokuEngine(yomitoku_bin=_fake_binary(tmp_path), progress=True)
+
+    engine.run_batch(pngs)
+
+    assert mock_tqdm.call_count == 0
+
+
+@patch("book_ocr.engines.yomitoku.tqdm")
+@patch("book_ocr.engines.yomitoku.subprocess.run", side_effect=_fake_yomitoku_subprocess)
+def test_tqdm_disable_kwarg_when_stderr_not_tty(
+    mock_run: MagicMock, mock_tqdm: MagicMock, tmp_path: Path
+) -> None:
+    """非 tty 環境では tqdm 呼び出し時に disable=True が渡される。"""
+    mock_tqdm.side_effect = lambda chunks, **kwargs: list(chunks)
+    pngs = _make_pngs(tmp_path, 4)
+    engine = YomiTokuEngine(yomitoku_bin=_fake_binary(tmp_path), chunk_size=2, progress=True)
+
+    engine.run_batch(pngs)
+
+    # pytest 環境では sys.stderr.isatty() == False のため disable=True
+    kwargs = mock_tqdm.call_args.kwargs
+    assert kwargs["disable"] is True

--- a/uv.lock
+++ b/uv.lock
@@ -432,12 +432,12 @@ source = { editable = "." }
 dependencies = [
     { name = "img2pdf" },
     { name = "pillow" },
+    { name = "tqdm" },
     { name = "typer" },
 ]
 
 [package.optional-dependencies]
 ocr = [
-    { name = "tqdm" },
     { name = "yomitoku" },
 ]
 
@@ -454,7 +454,7 @@ dev = [
 requires-dist = [
     { name = "img2pdf", specifier = ">=0.5" },
     { name = "pillow", specifier = ">=10.0" },
-    { name = "tqdm", marker = "extra == 'ocr'", specifier = ">=4.0" },
+    { name = "tqdm", specifier = ">=4.0" },
     { name = "typer", specifier = ">=0.16" },
     { name = "yomitoku", marker = "extra == 'ocr'", specifier = ">=0.4" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -437,6 +437,7 @@ dependencies = [
 
 [package.optional-dependencies]
 ocr = [
+    { name = "tqdm" },
     { name = "yomitoku" },
 ]
 
@@ -453,6 +454,7 @@ dev = [
 requires-dist = [
     { name = "img2pdf", specifier = ">=0.5" },
     { name = "pillow", specifier = ">=10.0" },
+    { name = "tqdm", marker = "extra == 'ocr'", specifier = ">=4.0" },
     { name = "typer", specifier = ">=0.16" },
     { name = "yomitoku", marker = "extra == 'ocr'", specifier = ">=0.4" },
 ]


### PR DESCRIPTION
## Summary

実書籍検証で 42 分の silent OCR 体感を改善。chunked 実行時、chunk 数 ≥ 2 かつ \`progress=True\` (default) で tqdm が \"OCR (chunks)\" の進捗を stderr に出す。

CI 等の非 tty 環境では \`disable=True\` で自動的に no-op。\`--no-progress\` で明示抑制可。

## 設計判断

- **chunk 単位**: yomitoku は per-page 進捗 hook を提供しないため、ページ単位は出せない
- **stderr**: 標準出力には \"OCR complete: ...\" 等の結果メッセージのみ。stderr に進捗を出すことで `>` リダイレクトと共存可能
- **tqdm を [ocr] extra に明示追加**: 既に yomitoku の transitive dep だが、明示化で意図を伝える

## Test plan

- [x] tqdm 呼び出しテスト (chunked + progress=True)
- [x] tqdm 非呼び出しテスト (progress=False / chunk 数=1)
- [x] 非 tty 環境で disable=True 渡し確認
- [x] CLI \`--no-progress\` フラグ伝搬テスト
- [x] 301 passed (+7) / mypy clean / ruff format & check passed