### PR TITLE
feat(book-ocr): --skip-existing で既存 page md の再 OCR を回避 (closes #41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `book-ocr --start-page N` / `--end-page M` CLI オプション：1-indexed inclusive で OCR 対象範囲を絞れる。失敗後の局所再走 (chunked 実行と組み合わせた retry や、巨大本の段階的処理) に有効（issue #39）
 - `book-ocr --progress` / `--no-progress` CLI オプション + `YomiTokuEngine.progress`：chunked 実行時に `tqdm` で chunk 単位の進捗を stderr に表示。chunk 数 < 2 や非 tty 環境では自動的に無効化（issue #38）
 - `tqdm>=4.0` を base 依存に追加（chunked 進捗表示で必要、CI でも常時入手するため `[ocr]` extra ではなく base に置く）
+- `book-ocr --skip-existing` CLI オプション + `book_ocr.cli.run_ocr_pipeline(..., skip_existing=True)`：既存 `pages/page_NNN.md` があるページは OCR をスキップ。失敗後 chunk 単位 retry を高速化。空ファイルは missing 扱いで再 OCR される。既存 md 先頭の `<!-- page:NNN -->` プレフィクスは render_page_md と対称に剥がして PageText を再構成する（issue #41）
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ output/my-book.pdf                # 既存。視覚確認用
 | `--start-page N` | `1` | OCR 開始ページ番号 (1-indexed inclusive、issue #39) |
 | `--end-page M` | None | OCR 終了ページ番号 (1-indexed inclusive、省略時は最後まで、issue #39) |
 | `--progress / --no-progress` | `--progress` | chunked 実行時に tqdm で chunk 進捗を stderr に表示 (issue #38) |
+| `--skip-existing` | off | 既存 `pages/page_NNN.md` があるページは OCR をスキップ (issue #41)。失敗後の再走を高速化 |
 
 #### 性能の目安（Apple Silicon MPS）
 

--- a/src/book_ocr/cli.py
+++ b/src/book_ocr/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import time
 from dataclasses import replace
 from datetime import UTC, datetime
@@ -11,9 +12,13 @@ import typer
 
 from book_ocr import orchestrator, writer
 from book_ocr.engines.yomitoku import YomiTokuEngine
+from book_ocr.exporters.book_md import render_book_md
 from book_ocr.exporters.json_index import render_index
-from book_ocr.models import BookMetadata
+from book_ocr.models import BookMetadata, PageText
 from book_ocr.protocols import OCREngine
+
+# render_page_md と対称な逆解析: 先頭の "<!-- page:NNN -->\n\n" を取り除く
+_PAGE_MARKER_RE = re.compile(r"^<!--\s*page:\d+\s*-->\s*\n+", re.DOTALL)
 
 
 def run_ocr_pipeline(
@@ -29,6 +34,7 @@ def run_ocr_pipeline(
     start_page: int = 1,
     end_page: int | None = None,
     progress: bool = True,
+    skip_existing: bool = False,
 ) -> Path:
     """指定した book_dir 内の page_*.png を OCR して Markdown / index.json を出力する.
 
@@ -65,6 +71,14 @@ def run_ocr_pipeline(
         progress=progress,
     )
     captured_at = datetime.now(UTC)
+
+    existing_pages: list[PageText] = []
+    pngs_to_ocr: list[Path] = list(pngs)
+    if skip_existing:
+        existing_pages, pngs_to_ocr = _partition_existing_pages(
+            pngs, out_dir / "pages", engine.name
+        )
+
     initial_meta = BookMetadata(
         title=title,
         page_count=len(pngs),
@@ -76,7 +90,19 @@ def run_ocr_pipeline(
     )
 
     t0 = time.perf_counter()
-    pages, _index_dict_pre, book_md_str = orchestrator.run(engine, initial_meta, pngs)
+    if pngs_to_ocr:
+        if existing_pages:
+            new_pages = engine.run_batch(pngs_to_ocr)
+            pages = _merge_pages(existing_pages, new_pages)
+            book_md_str = render_book_md(pages)
+        else:
+            pages, _index_dict_pre, book_md_str = orchestrator.run(
+                engine, initial_meta, pngs_to_ocr
+            )
+    else:
+        # 全ページ既存 → engine 呼ばず、保存済み内容で book_md を再生成
+        pages = sorted(existing_pages, key=lambda p: p.page_number)
+        book_md_str = render_book_md(pages)
     duration_sec = time.perf_counter() - t0
     finished_at = datetime.now(UTC)
 
@@ -156,6 +182,14 @@ def ocr(
             "非 tty 環境では自動的に無効化される。"
         ),
     ),
+    skip_existing: bool = typer.Option(
+        False,
+        "--skip-existing",
+        help=(
+            "既存 `pages/page_NNN.md` があるページの OCR をスキップ (issue #41)。"
+            "失敗後の再走で chunk 単位 retry を高速化する。空ファイルは missing 扱い。"
+        ),
+    ),
 ) -> None:
     """指定した book_dir 内の page_*.png を OCR して Markdown / index.json を生成する."""
     try:
@@ -171,6 +205,7 @@ def ocr(
             start_page=start_page,
             end_page=end_page,
             progress=progress,
+            skip_existing=skip_existing,
         )
     except FileNotFoundError as e:
         typer.echo(str(e), err=True)
@@ -184,6 +219,46 @@ def ocr(
 def _parse_page_number(p: Path) -> int:
     """`page_NNN.png` から NNN を取り出す。issue #39 の範囲フィルタで使う。"""
     return int(p.stem.split("_")[-1])
+
+
+def _partition_existing_pages(
+    pngs: list[Path], pages_dir: Path, engine_name: str
+) -> tuple[list[PageText], list[Path]]:
+    """`--skip-existing` 用 (issue #41): 既存 `pages/page_NNN.md` を読み出して
+    PageText に再構成し、未存在のページを OCR 対象として返す。
+
+    既存 md 先頭の `<!-- page:NNN -->` プレフィクスは render_page_md と対称に剥がす。
+    空ファイルは `missing` 扱いで再 OCR にまわす (壊れた状態のフォールバック)。"""
+    existing: list[PageText] = []
+    to_ocr: list[Path] = []
+    for png in pngs:
+        n = _parse_page_number(png)
+        md_path = pages_dir / f"page_{n:03d}.md"
+        if not md_path.exists() or md_path.stat().st_size == 0:
+            to_ocr.append(png)
+            continue
+        content = md_path.read_text(encoding="utf-8")
+        body = _PAGE_MARKER_RE.sub("", content, count=1)
+        existing.append(
+            PageText(
+                page_number=n,
+                png_path=png,
+                markdown=body,
+                ocr_engine=engine_name,
+            )
+        )
+    return existing, to_ocr
+
+
+def _merge_pages(existing: list[PageText], new: list[PageText]) -> list[PageText]:
+    """既存ページと新規 OCR ページを page_number 昇順でマージ。重複検出。"""
+    combined = sorted(existing + new, key=lambda p: p.page_number)
+    seen: set[int] = set()
+    for p in combined:
+        if p.page_number in seen:
+            raise ValueError(f"duplicate page_number {p.page_number} after merge")
+        seen.add(p.page_number)
+    return combined
 
 
 def run_ocr() -> None:

--- a/tests/unit/test_book_ocr_cli.py
+++ b/tests/unit/test_book_ocr_cli.py
@@ -288,6 +288,130 @@ class TestPageRangeOption:
         assert "No page_*.png" in result.stdout or "No page_*.png" in (result.stderr or "")
 
 
+class TestSkipExistingOption:
+    """issue #41: --skip-existing で既存 page_NNN.md があるページは OCR をスキップ。"""
+
+    def _seed_existing_page(self, book: Path, n: int, body: str) -> None:
+        """`book/pages/page_NNN.md` に render_page_md と同じフォーマットで書き込む。"""
+        pages_dir = book / "pages"
+        pages_dir.mkdir(exist_ok=True)
+        (pages_dir / f"page_{n:03d}.md").write_text(
+            f"<!-- page:{n:03d} -->\n\n{body}", encoding="utf-8"
+        )
+
+    def test_default_skip_existing_is_false(self, tmp_path: Path) -> None:
+        """default では既存 md があっても全ページ OCR する。"""
+        book = _make_book_dir(tmp_path, n_pages=3)
+        self._seed_existing_page(book, 1, "old content for page 1")
+
+        # FakeEngine が呼び出された pngs を記録
+        seen: list[Path] = []
+
+        class CapturingEngine(FakeEngine):
+            def run_batch(self, pngs: list[Path]) -> list[PageText]:
+                seen.extend(pngs)
+                return super().run_batch(pngs)
+
+        run_ocr_pipeline(book_dir=book, engine=CapturingEngine())
+        assert len(seen) == 3  # 既存があっても 3 枚すべて OCR
+
+    def test_skip_existing_skips_pages_with_existing_md(self, tmp_path: Path) -> None:
+        """既存 page_001.md があれば page_001 は OCR されない。"""
+        book = _make_book_dir(tmp_path, n_pages=3)
+        self._seed_existing_page(book, 1, "old content for page 1")
+
+        seen: list[Path] = []
+
+        class CapturingEngine(FakeEngine):
+            def run_batch(self, pngs: list[Path]) -> list[PageText]:
+                seen.extend(pngs)
+                return super().run_batch(pngs)
+
+        run_ocr_pipeline(book_dir=book, engine=CapturingEngine(), skip_existing=True)
+        # page_002, page_003 のみ OCR
+        assert sorted(p.name for p in seen) == ["page_002.png", "page_003.png"]
+
+    def test_skip_existing_preserves_old_content_in_book_md(self, tmp_path: Path) -> None:
+        """skip された既存ページは markdown 本体が保持され、book_md に含まれる。"""
+        book = _make_book_dir(tmp_path, n_pages=2)
+        self._seed_existing_page(book, 1, "OLD CONTENT FOR PAGE 1")
+
+        run_ocr_pipeline(book_dir=book, engine=FakeEngine(), skip_existing=True)
+
+        book_md = (book / "my-book.md").read_text(encoding="utf-8")
+        assert "OLD CONTENT FOR PAGE 1" in book_md  # 既存 page 1 は保持
+        assert "OCR for page_002.png" in book_md  # 新規 page 2 は OCR
+
+    def test_skip_existing_with_no_existing_runs_all(self, tmp_path: Path) -> None:
+        book = _make_book_dir(tmp_path, n_pages=2)
+        # 既存 md なし
+
+        seen: list[Path] = []
+
+        class CapturingEngine(FakeEngine):
+            def run_batch(self, pngs: list[Path]) -> list[PageText]:
+                seen.extend(pngs)
+                return super().run_batch(pngs)
+
+        run_ocr_pipeline(book_dir=book, engine=CapturingEngine(), skip_existing=True)
+        assert len(seen) == 2
+
+    def test_skip_existing_all_pages_existing_no_engine_call(self, tmp_path: Path) -> None:
+        """全ページの md がすでにあれば engine は呼ばれない (高速化)。"""
+        book = _make_book_dir(tmp_path, n_pages=2)
+        self._seed_existing_page(book, 1, "p1")
+        self._seed_existing_page(book, 2, "p2")
+
+        engine_call_count = 0
+
+        class CountingEngine(FakeEngine):
+            def run_batch(self, pngs: list[Path]) -> list[PageText]:
+                nonlocal engine_call_count
+                engine_call_count += 1
+                return super().run_batch(pngs)
+
+        run_ocr_pipeline(book_dir=book, engine=CountingEngine(), skip_existing=True)
+        assert engine_call_count == 0
+
+    def test_skip_existing_empty_md_treated_as_missing(self, tmp_path: Path) -> None:
+        """既存 md が空ファイルなら再 OCR する (壊れた状態のフォールバック)。"""
+        book = _make_book_dir(tmp_path, n_pages=2)
+        pages_dir = book / "pages"
+        pages_dir.mkdir()
+        (pages_dir / "page_001.md").write_text("", encoding="utf-8")
+
+        seen: list[Path] = []
+
+        class CapturingEngine(FakeEngine):
+            def run_batch(self, pngs: list[Path]) -> list[PageText]:
+                seen.extend(pngs)
+                return super().run_batch(pngs)
+
+        run_ocr_pipeline(book_dir=book, engine=CapturingEngine(), skip_existing=True)
+        # 空ファイル page_001 も再 OCR、page_002 も新規 OCR
+        assert len(seen) == 2
+
+    def test_index_page_count_includes_skipped(self, tmp_path: Path) -> None:
+        """skipped ページも index.json の page_count に含まれる。"""
+        book = _make_book_dir(tmp_path, n_pages=3)
+        self._seed_existing_page(book, 1, "p1")
+
+        run_ocr_pipeline(book_dir=book, engine=FakeEngine(), skip_existing=True)
+
+        data = json.loads((book / "index.json").read_text(encoding="utf-8"))
+        assert data["page_count"] == 3
+
+    def test_cli_skip_existing_flag_parses(self, tmp_path: Path) -> None:
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        app = typer.Typer()
+        app.command()(cli.ocr)
+        runner = CliRunner()
+        result = runner.invoke(app, [str(empty), "--skip-existing"])
+        assert result.exit_code != 0
+        assert "No page_*.png" in result.stdout or "No page_*.png" in (result.stderr or "")
+
+
 class TestProgressOption:
     """issue #38: --progress / --no-progress が YomiTokuEngine に伝搬する。"""
 


### PR DESCRIPTION
## Summary

\`book-ocr book/ --skip-existing\` で、\`pages/page_NNN.md\` が既存のページは OCR スキップ。失敗後の再走で chunk 単位 retry を高速化。

実装:
- \`_partition_existing_pages\`: 既存 md → PageText 復元、未存在は to_ocr リストに分ける
- \`_merge_pages\`: 既存 + 新規を page_number 順に統合 (重複検出付き)
- 全ページ既存なら engine 呼ばず (yomitoku の重い model load 回避)

## 設計

- \`render_page_md\` が前置する \`<!-- page:NNN -->\` プレフィクスは正規表現で剥がして \`PageText.markdown\` を復元 (対称な逆解析)
- 空ファイルは missing 扱いで再 OCR (壊れた状態のフォールバック)
- 既存ファイルから復元される \`PageText\` の \`ocr_engine\` は現在の engine 名を使う (元々の値が記録されていないため近似)

## Test plan

- [x] default で skip しない (既存があっても全 OCR)
- [x] skip-existing で既存スキップ + 不足分のみ OCR
- [x] 既存ページの md 内容が book_md に保持される
- [x] 全ページ既存で engine が呼ばれない (高速化確認)
- [x] 空ファイルは missing 扱いで再 OCR
- [x] index.json の page_count は skipped + 新規の合計
- [x] CLI flag parse smoke
- [x] 309 passed (+8) / mypy clean / ruff format & check passed

## Closes
\`Closes #41\`