### PR TITLE
feat(kindle-cap): --pdf-jpeg-quality で PDF サイズを ~1/10 縮小

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `book-ocr --progress` / `--no-progress` CLI オプション + `YomiTokuEngine.progress`：chunked 実行時に `tqdm` で chunk 単位の進捗を stderr に表示。chunk 数 < 2 や非 tty 環境では自動的に無効化（issue #38）
 - `tqdm>=4.0` を base 依存に追加（chunked 進捗表示で必要、CI でも常時入手するため `[ocr]` extra ではなく base に置く）
 - `book-ocr --skip-existing` CLI オプション + `book_ocr.cli.run_ocr_pipeline(..., skip_existing=True)`：既存 `pages/page_NNN.md` があるページは OCR をスキップ。失敗後 chunk 単位 retry を高速化。空ファイルは missing 扱いで再 OCR される。既存 md 先頭の `<!-- page:NNN -->` プレフィクスは render_page_md と対称に剥がして PageText を再構成する（issue #41）
+- `--pdf-jpeg-quality N` CLI オプション (`kindle-cap` / `kindle-cap-pdf` 双方) + `CaptureConfig.pdf_jpeg_quality` + `build_pdf(..., jpeg_quality=N)`：PDF 埋め込み画像を JPEG quality N (1-100) で再圧縮。未指定時は従来通り lossless PNG 埋め込み。テキスト書籍では quality 80 程度で同解像度のまま PDF サイズが ~1/10 になる (issue #50)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ output/my-book.pdf
 | `--keep-png / --no-keep-png` | | `--keep-png` | 中間 PNG を保持するか |
 | `--dry-run` | | off | 1 枚だけ撮って位置確認用に保存（PDF は作らない） |
 | `--auto-stop` | | off | 連続する 2 ページが同一なら書籍末尾と判断して停止 |
+| `--pdf-jpeg-quality N` | | （未指定） | PDF 埋め込み画像を JPEG quality N (1-100) で再圧縮。未指定時は lossless PNG 埋め込み。**テキスト書籍は 80 程度推奨で PDF サイズが ~1/10 に** (issue #50) |
 
 ※ `--direction` または `--auto-direction` のいずれかが必須（同時指定はエラー）
 
@@ -116,6 +117,9 @@ output/my-book.pdf
 ```bash
 uv run kindle-cap-pdf output/my-book
 # → output/my-book.pdf を再生成
+
+# JPEG 再圧縮で PDF サイズを縮小 (テキスト書籍向け)
+uv run kindle-cap-pdf output/my-book --pdf-jpeg-quality 80
 ```
 
 ### book-ocr — OCR で Markdown / index.json を生成（オプション）

--- a/src/kindle_cap/cli.py
+++ b/src/kindle_cap/cli.py
@@ -45,6 +45,15 @@ def capture(
         "--auto-stop",
         help="連続する 2 ページが同一なら書籍末尾と判断して停止",
     ),
+    pdf_jpeg_quality: int | None = typer.Option(
+        None,
+        "--pdf-jpeg-quality",
+        help=(
+            "PDF 埋め込み画像を JPEG quality N (1-100) で再圧縮。"
+            "未指定時は lossless PNG 埋め込み (~10x サイズ)。"
+            "テキスト書籍は 80 程度推奨"
+        ),
+    ),
 ) -> None:
     if direction is not None and auto_direction:
         raise typer.BadParameter(
@@ -60,14 +69,18 @@ def capture(
     if name is None:
         name = typer.prompt("書籍名 (出力ディレクトリ名)")
 
-    config = CaptureConfig(
-        name=name,
-        pages=pages,
-        direction=direction,
-        wait=wait,
-        out=out,
-        keep_png=keep_png,
-    )
+    try:
+        config = CaptureConfig(
+            name=name,
+            pages=pages,
+            direction=direction,
+            wait=wait,
+            out=out,
+            keep_png=keep_png,
+            pdf_jpeg_quality=pdf_jpeg_quality,
+        )
+    except ValueError as e:
+        raise typer.BadParameter(str(e)) from e
 
     try:
         orchestrator_run(
@@ -93,6 +106,13 @@ def rebuild_pdf(
         readable=True,
         help="page_*.png を含むディレクトリ",
     ),
+    pdf_jpeg_quality: int | None = typer.Option(
+        None,
+        "--pdf-jpeg-quality",
+        help=(
+            "PDF 埋め込み画像を JPEG quality N (1-100) で再圧縮。未指定時は lossless PNG 埋め込み"
+        ),
+    ),
 ) -> None:
     pngs = sorted(directory.glob("page_*.png"))
     if not pngs:
@@ -100,8 +120,11 @@ def rebuild_pdf(
         raise typer.Exit(code=1)
     out_path = directory.parent / f"{directory.name}.pdf"
     try:
-        build_pdf(pngs, out_path)
+        build_pdf(pngs, out_path, jpeg_quality=pdf_jpeg_quality)
     except PdfBuildError as e:
+        typer.echo(f"[エラー] {e}", err=True)
+        raise typer.Exit(code=1) from e
+    except ValueError as e:
         typer.echo(f"[エラー] {e}", err=True)
         raise typer.Exit(code=1) from e
     typer.echo(f"PDF を作成しました: {out_path}")

--- a/src/kindle_cap/config.py
+++ b/src/kindle_cap/config.py
@@ -26,6 +26,7 @@ class CaptureConfig:
     wait: float
     out: Path
     keep_png: bool
+    pdf_jpeg_quality: int | None = None
 
     def __post_init__(self) -> None:
         if self.pages <= 0:
@@ -40,3 +41,5 @@ class CaptureConfig:
             raise ValueError("name must not contain null bytes")
         if self.name in (".", ".."):
             raise ValueError("name must not be '.' or '..'")
+        if self.pdf_jpeg_quality is not None and not (1 <= self.pdf_jpeg_quality <= 100):
+            raise ValueError(f"pdf_jpeg_quality must be in 1..100 (got {self.pdf_jpeg_quality})")

--- a/src/kindle_cap/orchestrator.py
+++ b/src/kindle_cap/orchestrator.py
@@ -132,7 +132,7 @@ def _capture_book(
         return
 
     pdf_path = config.out / f"{config.name}.pdf"
-    build_pdf(captured, pdf_path)
+    build_pdf(captured, pdf_path, jpeg_quality=config.pdf_jpeg_quality)
 
     if not config.keep_png:
         for p in captured:

--- a/src/kindle_cap/pdf.py
+++ b/src/kindle_cap/pdf.py
@@ -1,25 +1,54 @@
-"""Combine PNG images into a single PDF using img2pdf (lossless)."""
+"""Combine PNG images into a single PDF using img2pdf.
+
+`jpeg_quality` 未指定時は PNG を lossless で埋め込む (img2pdf のデフォルト動作)。
+指定時は Pillow で各 PNG を JPEG bytes に再圧縮してから埋め込み、PDF サイズを
+~1/10 に縮小可能にする (テキスト書籍向けの trade-off オプション)。
+"""
 
 import errno
+from io import BytesIO
 from pathlib import Path
 
 import img2pdf
+from PIL import Image
 
 
 class PdfBuildError(Exception):
     """build_pdf がディスク容量不足など予測可能な要因で失敗したことを表す."""
 
 
-def build_pdf(png_paths: list[Path], out_path: Path) -> None:
+def _png_to_jpeg_bytes(png_path: Path, quality: int) -> bytes:
+    with Image.open(png_path) as img:
+        rgb = img.convert("RGB") if img.mode != "RGB" else img
+        buf = BytesIO()
+        rgb.save(buf, format="JPEG", quality=quality, optimize=True)
+        return buf.getvalue()
+
+
+def build_pdf(
+    png_paths: list[Path],
+    out_path: Path,
+    *,
+    jpeg_quality: int | None = None,
+) -> None:
     if not png_paths:
         raise ValueError("png_paths must not be empty")
+    if jpeg_quality is not None and not (1 <= jpeg_quality <= 100):
+        raise ValueError(f"jpeg_quality must be in 1..100 (got {jpeg_quality})")
     out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    inputs: list[str] | list[bytes]
+    if jpeg_quality is None:
+        inputs = [str(p) for p in png_paths]
+    else:
+        inputs = [_png_to_jpeg_bytes(p, jpeg_quality) for p in png_paths]
+
     # outputstream を渡すことで、PDF 全体を一度メモリに展開せずに直接ファイルへ
     # 書き出せる。1000+ ページのリフロー型書籍など長尺キャプチャに対応するため
     # ストリーム出力を採用。
     try:
         with open(out_path, "wb") as fp:
-            img2pdf.convert([str(p) for p in png_paths], outputstream=fp)
+            img2pdf.convert(inputs, outputstream=fp)
     except OSError as e:
         # 中途半端に書かれた PDF は再生成のじゃまになるので削除
         out_path.unlink(missing_ok=True)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -306,3 +306,90 @@ def test_capture_auto_direction_combined_with_auto_stop(
     assert result.exit_code == 0, result.output
     assert mock_run.call_args.kwargs.get("auto_direction") is True
     assert mock_run.call_args.kwargs.get("auto_stop") is True
+
+
+# ---------------------------------------------------------------------------
+# --pdf-jpeg-quality
+# ---------------------------------------------------------------------------
+
+
+@patch("kindle_cap.cli.orchestrator_run")
+def test_capture_pdf_jpeg_quality_default_is_none(mock_run: MagicMock, tmp_path: Path) -> None:
+    app = _make_app(capture)
+    result = runner.invoke(
+        app,
+        ["--name", "x", "--pages", "1", "--direction", "rtl", "--out", str(tmp_path)],
+    )
+    assert result.exit_code == 0, result.output
+    assert mock_run.call_args.args[0].pdf_jpeg_quality is None
+
+
+@patch("kindle_cap.cli.orchestrator_run")
+def test_capture_pdf_jpeg_quality_passes_through(mock_run: MagicMock, tmp_path: Path) -> None:
+    app = _make_app(capture)
+    result = runner.invoke(
+        app,
+        [
+            "--name",
+            "x",
+            "--pages",
+            "1",
+            "--direction",
+            "rtl",
+            "--out",
+            str(tmp_path),
+            "--pdf-jpeg-quality",
+            "80",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert mock_run.call_args.args[0].pdf_jpeg_quality == 80
+
+
+@patch("kindle_cap.cli.orchestrator_run")
+def test_capture_pdf_jpeg_quality_out_of_range_exits_nonzero(
+    mock_run: MagicMock, tmp_path: Path
+) -> None:
+    """範囲外 (0 / 101) は CaptureConfig の validation で BadParameter になり exit 非 0."""
+    app = _make_app(capture)
+    result = runner.invoke(
+        app,
+        [
+            "--name",
+            "x",
+            "--pages",
+            "1",
+            "--direction",
+            "rtl",
+            "--out",
+            str(tmp_path),
+            "--pdf-jpeg-quality",
+            "0",
+        ],
+    )
+    assert result.exit_code != 0
+    assert not mock_run.called
+
+
+@patch("kindle_cap.cli.build_pdf")
+def test_rebuild_pdf_pdf_jpeg_quality_passes_through(mock_build: MagicMock, tmp_path: Path) -> None:
+    book = tmp_path / "my-book"
+    book.mkdir()
+    (book / "page_001.png").write_bytes(b"a")
+    app = _make_app(rebuild_pdf)
+    result = runner.invoke(app, [str(book), "--pdf-jpeg-quality", "70"])
+    assert result.exit_code == 0, result.output
+    assert mock_build.call_args.kwargs.get("jpeg_quality") == 70
+
+
+@patch("kindle_cap.cli.build_pdf")
+def test_rebuild_pdf_pdf_jpeg_quality_default_is_none(
+    mock_build: MagicMock, tmp_path: Path
+) -> None:
+    book = tmp_path / "my-book"
+    book.mkdir()
+    (book / "page_001.png").write_bytes(b"a")
+    app = _make_app(rebuild_pdf)
+    result = runner.invoke(app, [str(book)])
+    assert result.exit_code == 0, result.output
+    assert mock_build.call_args.kwargs.get("jpeg_quality") is None

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -199,3 +199,44 @@ def test_config_direction_none_allowed() -> None:
     """auto-direction 経路で direction が確定するまで None を保持できる。"""
     c = CaptureConfig(**_valid_config_kwargs(direction=None))
     assert c.direction is None
+
+
+# ---------------------------------------------------------------------------
+# CaptureConfig: pdf_jpeg_quality 境界値
+# ---------------------------------------------------------------------------
+
+
+def test_config_pdf_jpeg_quality_default_is_none() -> None:
+    """未指定なら現状動作 (lossless PNG embed) を保つ."""
+    c = CaptureConfig(**_valid_config_kwargs())
+    assert c.pdf_jpeg_quality is None
+
+
+def test_config_pdf_jpeg_quality_accepts_int() -> None:
+    c = CaptureConfig(**_valid_config_kwargs(pdf_jpeg_quality=80))
+    assert c.pdf_jpeg_quality == 80
+
+
+def test_config_pdf_jpeg_quality_boundary_one_accepted() -> None:
+    c = CaptureConfig(**_valid_config_kwargs(pdf_jpeg_quality=1))
+    assert c.pdf_jpeg_quality == 1
+
+
+def test_config_pdf_jpeg_quality_boundary_hundred_accepted() -> None:
+    c = CaptureConfig(**_valid_config_kwargs(pdf_jpeg_quality=100))
+    assert c.pdf_jpeg_quality == 100
+
+
+def test_config_pdf_jpeg_quality_zero_rejected() -> None:
+    with pytest.raises(ValueError, match="pdf_jpeg_quality"):
+        CaptureConfig(**_valid_config_kwargs(pdf_jpeg_quality=0))
+
+
+def test_config_pdf_jpeg_quality_one_oh_one_rejected() -> None:
+    with pytest.raises(ValueError, match="pdf_jpeg_quality"):
+        CaptureConfig(**_valid_config_kwargs(pdf_jpeg_quality=101))
+
+
+def test_config_pdf_jpeg_quality_negative_rejected() -> None:
+    with pytest.raises(ValueError, match="pdf_jpeg_quality"):
+        CaptureConfig(**_valid_config_kwargs(pdf_jpeg_quality=-1))

--- a/tests/unit/test_pdf.py
+++ b/tests/unit/test_pdf.py
@@ -261,3 +261,115 @@ def test_build_pdf_removes_partial_pdf_on_other_oserror(tmp_path: Path) -> None:
         build_pdf([p], out)
 
     assert not out.exists(), "原例外 OSError でも部分 PDF は削除する"
+
+
+# ---------------------------------------------------------------------------
+# JPEG quality option (PDF サイズ縮小)
+# ---------------------------------------------------------------------------
+
+
+def _make_noisy_png(path: Path, size: tuple[int, int] = (400, 400)) -> Path:
+    """JPEG 圧縮効果が現れるように、ノイズを含む PNG を生成する.
+
+    単色 PNG だと JPEG / PNG どちらでも極小サイズに圧縮されるため、
+    `--pdf-jpeg-quality` の効果検証には判定不能。`Image.effect_noise` で
+    高エントロピーのグレー画像を作り、PNG (lossless) と JPEG (lossy)
+    のサイズ差を実測可能にする。
+    """
+    Image.effect_noise(size, sigma=64).convert("RGB").save(path, format="PNG")
+    return path
+
+
+def test_build_pdf_jpeg_quality_none_keeps_existing_path_input(tmp_path: Path) -> None:
+    """jpeg_quality=None (デフォルト) では img2pdf にパス文字列リストを渡す (現状動作)."""
+    pngs = [_make_rgb_png(tmp_path / "p.png")]
+    captured_args: dict[str, Any] = {}
+
+    real_convert = __import__("img2pdf").convert
+
+    def spy(*args: Any, **kwargs: Any) -> Any:
+        captured_args["positional"] = args
+        return real_convert(*args, **kwargs)
+
+    with patch("kindle_cap.pdf.img2pdf.convert", side_effect=spy):
+        build_pdf(pngs, tmp_path / "out.pdf")
+
+    first = captured_args["positional"][0]
+    assert isinstance(first, list)
+    assert all(isinstance(x, str) for x in first), (
+        "jpeg_quality 未指定時はパス文字列のまま渡し、現状の lossless PNG embed を維持する"
+    )
+
+
+def test_build_pdf_jpeg_quality_passes_bytes_to_img2pdf(tmp_path: Path) -> None:
+    """jpeg_quality 指定時は Pillow で JPEG bytes に変換した結果を img2pdf に渡す."""
+    pngs = [_make_rgb_png(tmp_path / "p.png")]
+    captured_args: dict[str, Any] = {}
+
+    real_convert = __import__("img2pdf").convert
+
+    def spy(*args: Any, **kwargs: Any) -> Any:
+        captured_args["positional"] = args
+        return real_convert(*args, **kwargs)
+
+    with patch("kindle_cap.pdf.img2pdf.convert", side_effect=spy):
+        build_pdf(pngs, tmp_path / "out.pdf", jpeg_quality=80)
+
+    first = captured_args["positional"][0]
+    assert isinstance(first, list)
+    assert all(isinstance(x, bytes) for x in first)
+    assert first[0].startswith(b"\xff\xd8\xff"), "JPEG SOI marker (FFD8FF) で始まる bytes である"
+
+
+def test_build_pdf_jpeg_quality_creates_smaller_pdf(tmp_path: Path) -> None:
+    """ノイズ画像で JPEG 80 と lossless PNG の PDF サイズを比較し、JPEG 版が小さいこと."""
+    pngs = [_make_noisy_png(tmp_path / f"p_{i}.png") for i in range(3)]
+    out_lossless = tmp_path / "lossless.pdf"
+    out_jpeg = tmp_path / "jpeg.pdf"
+
+    build_pdf(pngs, out_lossless)
+    build_pdf(pngs, out_jpeg, jpeg_quality=50)
+
+    lossless_size = out_lossless.stat().st_size
+    jpeg_size = out_jpeg.stat().st_size
+    assert jpeg_size < lossless_size, (
+        f"JPEG quality=50 (size={jpeg_size}) は lossless (size={lossless_size}) より小さくなるべき"
+    )
+
+
+def test_build_pdf_jpeg_quality_produces_valid_pdf(tmp_path: Path) -> None:
+    """jpeg_quality 指定時も pypdf でページ数が読める正しい PDF を生成する."""
+    pngs = [_make_rgb_png(tmp_path / f"p_{i}.png") for i in range(3)]
+    out = tmp_path / "out.pdf"
+    build_pdf(pngs, out, jpeg_quality=80)
+    assert len(PdfReader(str(out)).pages) == 3
+
+
+def test_build_pdf_jpeg_quality_handles_rgba_png(tmp_path: Path) -> None:
+    """RGBA PNG (透過あり) も JPEG 変換できる (RGB に flatten される)."""
+    p = tmp_path / "rgba.png"
+    Image.new("RGBA", (100, 100), (255, 0, 0, 128)).save(p)
+    out = tmp_path / "rgba.pdf"
+    build_pdf([p], out, jpeg_quality=80)
+    assert len(PdfReader(str(out)).pages) == 1
+
+
+def test_build_pdf_rejects_jpeg_quality_too_low(tmp_path: Path) -> None:
+    p = _make_rgb_png(tmp_path / "p.png")
+    with pytest.raises(ValueError, match="jpeg_quality"):
+        build_pdf([p], tmp_path / "out.pdf", jpeg_quality=0)
+
+
+def test_build_pdf_rejects_jpeg_quality_too_high(tmp_path: Path) -> None:
+    p = _make_rgb_png(tmp_path / "p.png")
+    with pytest.raises(ValueError, match="jpeg_quality"):
+        build_pdf([p], tmp_path / "out.pdf", jpeg_quality=101)
+
+
+def test_build_pdf_accepts_jpeg_quality_boundaries(tmp_path: Path) -> None:
+    """境界値 1 / 100 は受理する."""
+    p = _make_rgb_png(tmp_path / "p.png")
+    build_pdf([p], tmp_path / "q1.pdf", jpeg_quality=1)
+    build_pdf([p], tmp_path / "q100.pdf", jpeg_quality=100)
+    assert (tmp_path / "q1.pdf").exists()
+    assert (tmp_path / "q100.pdf").exists()


### PR DESCRIPTION
## Summary

- `--pdf-jpeg-quality N` (kindle-cap / kindle-cap-pdf 双方) を追加。PDF 埋め込み画像を JPEG quality N (1-100) で再圧縮 → テキスト書籍は **~1/10** に縮小可能 (例: アトミックシンキング 156 MB → ~15-20 MB 見込み)
- 未指定時は従来通り lossless PNG 埋め込み (回帰なし)
- `CaptureConfig.pdf_jpeg_quality` + `build_pdf(..., jpeg_quality=N)` 追加。`__post_init__` / `build_pdf` どちらも 1-100 範囲外で `ValueError`

親 issue #50 のチェックリスト #2 に対応。残り (#1 docs / #3 image-scale / #4 pdf-split / #5 quality 計測 PoC) は別 PR で順次。

## 設計判断

- **in-memory bytes**: Pillow で PNG → JPEG bytes に変換してから `img2pdf.convert([bytes, ...], outputstream=fp)` で渡す。一時ファイル方式より I/O が少なく、cleanup も不要。img2pdf の bytes 入力サポートは確認済み (v0.6.3)
- **デフォルトは None**: 未指定時の動作 = 現状の lossless PNG embed を保持。既存ユーザーへの影響ゼロ
- **CLI レイヤで ValueError → BadParameter 変換**: CaptureConfig の validation が CLI ユーザーに traceback ではなく分かりやすいエラーメッセージで届く

## Test plan

- [x] `pytest tests/unit/test_pdf.py` — 28 件 (新規 8 件: bytes spy / サイズ比較 / RGBA flatten / 境界値 0/1/100/101)
- [x] `pytest tests/unit/test_config.py` — 34 件 (新規 7 件: default None / 境界値 / 範囲外)
- [x] `pytest tests/unit/test_cli.py` — 20 件 (新規 5 件: capture / rebuild_pdf 各オプション伝搬 + 範囲外 exit)
- [x] `pytest` 全件 — 330 passed, 16 skipped (live マーカー)
- [x] `mypy src/` — Success
- [x] `ruff check src/ tests/` / `ruff format --check src/ tests/` — All passed
- [ ] **手動検証 (実書籍、別 PR の PoC で計測予定)**: `kindle-cap-pdf output/<book> --pdf-jpeg-quality 80` で実 PDF サイズと判読性を確認

## 既知の不確実性

- 1000 ページ × ~100 KB JPEG = ~100 MB の peak memory が発生する。Mac 8 GB 想定で許容範囲だが、巨大本では generator/iterator パスへの切替を検討の余地 (Follow-up)
