### PR TITLE
fix(kindle-cap): kindle-cap-pdf で 1000 ページ超の PDF ページ順序を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 ### Fixed
 
+- `kindle-cap-pdf`: 1000 ページを超える書籍で PDF のページ順序が破綻していたのを修正。`sorted(directory.glob("page_*.png"))` が辞書順だったため、`page_1000.png` (4 桁) が `page_101.png` (3 桁) より前に挿入されていた。例: 1453 ページ書籍では PDF 最終ページが `page_999.png` で終わり、本来の最終 `page_1453.png` は中盤に紛れていた。`page_NNN` の数値で sort するように修正
 - ディスク容量不足 (`ENOSPC`) で PDF 生成が失敗したときに生 traceback を露出していたのを改修。`PdfBuildError` を raise し、CLI で日本語の説明的メッセージ + exit 1 で終了する。部分書き込みされた PDF は削除し、PNG は保持して `kindle-cap-pdf` で再生成可能 (issue #19)
 - `docs/ocr-bench/2026-04-28.md` の markdownlint 警告 5 件 (MD040 / MD032 / MD036) を解消 (issue #20)
 - `book_ocr.engines.yomitoku.YomiTokuEngine`：yomitoku subprocess の stderr 握り潰しと timeout 未設定を改修。非ゼロ exit / timeout 双方で `stdout`/`stderr`/`exit code` を含む `RuntimeError` を raise (issue #21)

--- a/src/kindle_cap/cli.py
+++ b/src/kindle_cap/cli.py
@@ -1,5 +1,6 @@
 """Typer-based CLI entry points for kindle_cap."""
 
+import re
 from pathlib import Path
 
 import typer
@@ -8,6 +9,16 @@ from .config import CaptureConfig, Direction
 from .orchestrator import run as orchestrator_run
 from .pdf import PdfBuildError, build_pdf
 from .preflight import PreflightError
+
+# `page_{n:03d}.png` で生成された PNG を **数値順** に並べるためのキー。
+# 書籍が 1000 ページを超えると 3 桁と 4 桁が混在し、辞書順 sort では
+# `page_1000.png` が `page_101.png` より先に来てしまうため数値で比較する。
+_PAGE_NUM_RE = re.compile(r"page_(\d+)\.png$")
+
+
+def _page_num(p: Path) -> int:
+    m = _PAGE_NUM_RE.match(p.name)
+    return int(m.group(1)) if m else 0
 
 
 def capture(
@@ -114,7 +125,7 @@ def rebuild_pdf(
         ),
     ),
 ) -> None:
-    pngs = sorted(directory.glob("page_*.png"))
+    pngs = sorted(directory.glob("page_*.png"), key=_page_num)
     if not pngs:
         typer.echo(f"[エラー] {directory} に page_*.png が見つかりません", err=True)
         raise typer.Exit(code=1)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -393,3 +393,59 @@ def test_rebuild_pdf_pdf_jpeg_quality_default_is_none(
     result = runner.invoke(app, [str(book)])
     assert result.exit_code == 0, result.output
     assert mock_build.call_args.kwargs.get("jpeg_quality") is None
+
+
+# ---------------------------------------------------------------------------
+# rebuild_pdf: ページ番号の数値順ソート (1000+ ページ書籍の回帰防止)
+# ---------------------------------------------------------------------------
+
+
+@patch("kindle_cap.cli.build_pdf")
+def test_rebuild_pdf_orders_pngs_numerically_with_4digit_files(
+    mock_build: MagicMock, tmp_path: Path
+) -> None:
+    """3 桁/4 桁混在の書籍 (>=1000 ページ) でも PNG が数値順に並ぶ。
+
+    実際の bug: lex 順 sort だと page_1000.png が page_101.png より前に
+    挿入され、PDF のページ順序が破綻していた。
+    """
+    book = tmp_path / "huge-book"
+    book.mkdir()
+    page_nums = [1, 9, 10, 100, 999, 1000, 1099, 1100, 1453]
+    for n in page_nums:
+        (book / f"page_{n:03d}.png").write_bytes(b"")
+
+    app = _make_app(rebuild_pdf)
+    result = runner.invoke(app, [str(book)])
+
+    assert result.exit_code == 0, result.output
+    pngs_arg = mock_build.call_args.args[0]
+    received = [p.name for p in pngs_arg]
+    expected = [f"page_{n:03d}.png" for n in page_nums]
+    assert received == expected, (
+        f"PNG が数値順に並んでいない:\n  expected: {expected}\n  got:      {received}"
+    )
+
+
+@patch("kindle_cap.cli.build_pdf")
+def test_rebuild_pdf_orders_pngs_numerically_3digit_only(
+    mock_build: MagicMock, tmp_path: Path
+) -> None:
+    """1000 ページ未満 (3 桁のみ) の書籍は数値順 == lex 順で従来通り."""
+    book = tmp_path / "small-book"
+    book.mkdir()
+    for n in [1, 2, 50, 100, 999]:
+        (book / f"page_{n:03d}.png").write_bytes(b"")
+
+    app = _make_app(rebuild_pdf)
+    result = runner.invoke(app, [str(book)])
+
+    assert result.exit_code == 0, result.output
+    pngs_arg = mock_build.call_args.args[0]
+    assert [p.name for p in pngs_arg] == [
+        "page_001.png",
+        "page_002.png",
+        "page_050.png",
+        "page_100.png",
+        "page_999.png",
+    ]


### PR DESCRIPTION
## Summary

**bug**: `kindle-cap-pdf` で **1000 ページを超える書籍の PDF ページ順序が破綻**していた。`sorted(directory.glob("page_*.png"))` が辞書順 sort のため、`page_1000.png` (4 桁) が `page_101.png` (3 桁) より前に挿入されていた。

実書籍 (`output/プロになるためのWeb技術入門/` 1453 ページ) で実証:

| 期待 | 実際 (bug 発症時) |
|---|---|
| PDF page 1453 = page_1453.png (「おわりに」) | **page_999.png** (本の中盤) |
| page_1453.png の位置 | **PDF page 599 番目** に紛れ込み |
| page_1000.png の位置 | **PDF page 101 番目** (本来 1000) |

→ 読者にとっては **章順がまるで違う本**になっていた。

## Fix

`src/kindle_cap/cli.py` の `_page_num` ヘルパー (`page_NNN.png` の N を int で返す) を導入し、`sorted(..., key=_page_num)` で数値順ソート。

## Test plan

- [x] **TDD**: `tests/unit/test_cli.py` に 2 件追加
  - `test_rebuild_pdf_orders_pngs_numerically_with_4digit_files`: 3桁/4桁混在 (1, 9, 10, 100, 999, 1000, 1099, 1100, 1453) で数値順を assert (修正前 red、修正後 green)
  - `test_rebuild_pdf_orders_pngs_numerically_3digit_only`: 1000 ページ未満で挙動が変わらない回帰防止
- [x] `pytest`: 332 passed (+2), 16 skipped (live)
- [x] `mypy src/`: Success
- [x] `ruff check` / `format --check`: All passed

## 影響範囲

| 経路 | 影響 |
|---|---|
| `kindle-cap-pdf` (rebuild_pdf, glob 経由) | **修正対象** |
| `kindle-cap` (キャプチャ直後の build_pdf) | 影響なし — `_capture_book` が `captured: list[Path]` を append 順で渡すため |
| 1000 ページ未満の書籍 | **既存挙動と同じ** (回帰なし) |

## merge 後の再実行

ユーザー側で:

```bash
# 既存の (順序破綻済み) PDF を上書き再生成
uv run kindle-cap-pdf output/プロになるためのWeb技術入門 --pdf-jpeg-quality 80
```

## Follow-up

- 進捗表示が無くて UX が悪い件は #53 として別 issue 化済み
