### PR TITLE
docs(ai-readability): Claude Code 経由の PDF/markdown 実測レポート (closes #51)

### DIFF
--- a/docs/ai-readability/2026-05-20.md
+++ b/docs/ai-readability/2026-05-20.md
@@ -1,0 +1,146 @@
+# AI 読みやすさ評価: PDF vs book-ocr markdown (2026-05-20)
+
+## 結論 (TL;DR)
+
+- **`output/` 配下の現状 PDF を Claude Code に直接読ませる経路は事実上塞がれている** — 全 13 冊が **100 MB 超過** で Claude Code の `Read` ツール上限を超え、加えて Claude Code は PDF レンダリングに `poppler` (`pdftoppm`) を要求する。普段使いの環境にプリインストールされておらず追加セットアップが必要
+- **`book-ocr` の markdown は Claude Code でそのまま完璧に扱える** — yomitoku 出力品質も縦書き・横書きとも ◎、サイズは PDF の 500-600 分の 1、token 効率も良好
+- **`#50` の派生子 issue (`--pdf-image-scale` / `kindle-cap-pdf-split`) の優先度は低い** — 「Claude Code に読ませる」用途では markdown 路線で完結する。視覚確認 (図表参照) が必要な場面に限り、別途 `pypdf` ベースの抜粋スクリプト (~10 行) で十分代替できる
+
+## 目的
+
+`kindle-calibre-tool` の出力 (PDF / `book-ocr` markdown) を **Claude Code に読ませる** 実用性を実測し、`#50` 親 issue で提案されている子 issue 候補 (`--pdf-image-scale` / `kindle-cap-pdf-split` / JPEG quality 許容点調査) の必要性を確定させる。
+
+評価対象は **Claude Code (CLI)**。Anthropic API への直接投入は今回スコープ外。
+
+## 方法
+
+サンプル: `output/イシューからはじめよ.pdf` (237 MB / 305p、縦書き) と `output/Kaggleではじめる大規模言語モデル入門.pdf` (820 MB、横書き) の 2 冊。markdown は既存の PoC 成果物 (`experiments/ocr-poc/yomitoku-out/vertical|horizontal/`) を流用。
+
+手順:
+
+1. 現状 PDF を Claude Code の `Read` ツールに渡して上限挙動を確認
+2. `pypdf` で 32 MB 以下に抜粋した PDF を Claude Code に渡して挙動を確認
+3. `book-ocr` 出力の markdown を Claude Code に読ませて応答品質を確認
+4. PDF と markdown のサイズ / token 概算を比較
+
+## 環境
+
+- macOS Apple Silicon (Darwin 25.0.0)
+- Claude Code (CLI)
+- `uv run --with pypdf` で抜粋 (pypdf 6.10.2)
+- ディスク残量: 19 GiB / 228 GiB
+
+## 実測結果
+
+### 1. 現状 PDF を Claude Code に渡す
+
+`Read("/Users/.../output/イシューからはじめよ.pdf", pages="1-3")` を実行:
+
+```
+PDF file exceeds maximum allowed size for text extraction (100MB).
+```
+
+**観測**:
+
+- Claude Code の `Read` ツールは PDF に **独自の 100 MB 上限** を持つ。Anthropic API ドキュメント記載の 32 MB 上限とは別レイヤ
+- `output/` 配下の全 13 冊 (最小 148 MB 〜最大 820 MB) はこの上限を超えており、**そのままでは Claude Code に読ませられない**
+
+### 2. 32 MB 以下に抜粋した PDF を渡す
+
+`pypdf` で「イシューからはじめよ」冒頭を抜粋:
+
+| 抜粋ページ数 | サイズ |
+|---|---|
+| 20p | 13.9 MB |
+| 30p | 20.5 MB |
+| 50p | 36.4 MB |
+
+20p 抜粋を `Read("/tmp/issue_excerpt_20p.pdf", pages="3-5")` で読もうとすると:
+
+```
+pdftoppm is not installed. Install poppler-utils
+(e.g. `brew install poppler` or `apt-get install poppler-utils`)
+to enable PDF page rendering.
+```
+
+**観測**:
+
+- Claude Code は PDF を **ページ画像にレンダリング** する仕組み (`pdftoppm` 経由)。テキスト抽出ではなく、視覚モデルに渡す前提
+- macOS に `poppler` がプリインストールされていない環境では、サイズに関わらず PDF を読めない
+- ユーザー方針 (普段は `padawansato@gmail.com` で運用、Claude Code を主軸) を踏まえると、**「PDF を Claude Code に渡す」経路はそもそも追加セットアップが要る非デフォルト経路**
+
+### 3. book-ocr markdown を渡す
+
+`experiments/ocr-poc/yomitoku-out/vertical/samples-vertical_page_003_p1.md` (1,395 bytes) を `Read` で取得:
+
+```markdown
+Kindle
+
+イシューからはじめよー一知的生産の「シンプルな本質」
+
+# 優れた知的生産に共通すること
+
+はじめに
+
+僕がこれまでに見てきた「圧倒的に生産性の高い人」にひと<br>つ共通していることがある。それは、彼らが「ひとつのことを<br>やるスピードが10倍、20倍と速いわけではない」ということだ。
+...
+```
+
+横書き (`Kaggleではじめる大規模言語モデル入門`) も同様に、`<br>` で改行が保持された綺麗な markdown。
+
+**観測**:
+
+- Claude Code はそのまま `Read` で開ける。ツール側の上限制約に一切かからない
+- yomitoku の出力品質: 縦書き・横書きとも見出し検出 (`#`) + 段落保持 (`<br>`) ◎
+- `book-ocr` は `pages/page_NNN.md` を個別に出すので、長い書籍も「特定章だけ読ませる」がコスト最小で可能
+
+### 4. サイズ / token 比較
+
+| 観点 | 現状 PDF | book-ocr markdown |
+|---|---|---|
+| 1 ページあたり (縦書き本) | ~779 KB | ~1.4 KB |
+| サイズ比 | 1 | **1/500** |
+| 1 ページ token 概算 | 1,500-3,000 (Anthropic 公式; 画像) | 500-700 (日本語 ~1,200 文字相当) |
+| token 比 | 1 | **約 1/3-1/5** |
+| Claude Code 経由可否 | 非デフォルト経路 (要 poppler + 32-100 MB 上限管理) | デフォルトで可 |
+| 図表参照 | レンダリング画像で可 | 文字情報のみ (表は markdown 形式で構造保持、図は不可) |
+
+## 子 issue 候補への影響判断
+
+`#50` 親 issue では以下の子 issue が提案されていた:
+
+1. **docs: README に「AI 用途は markdown / PDF は視覚確認」明記** → **やる**。本評価結果を反映する小 PR で十分
+2. **feat: `--pdf-image-scale 0.5|0.75|1.0` で down-sample** → **保留**。Claude Code 経路では markdown が圧倒的に有利で、PDF を AI に読ませる動機が薄い。視覚確認 (人間が見る) 用途で必要になれば再検討
+3. **feat: `kindle-cap-pdf-split <book>.pdf --pages 100` で分割** → **保留** (上記と同じ理由)。なお必要時は `uv run --with pypdf python -c "..."` の 10 行スクリプトで代替可
+4. **investigation: JPEG quality と画質低下の許容点** → **保留**。`--pdf-jpeg-quality` (PR #52) で既に 1/10 圧縮できており、これ以上の調整は AI 用途には不要
+
+## 次のステップ
+
+1. `#50` にこの結論をコメントし、子 issue 候補 (上記 2-4) は **「Claude Code 経由用途には不要、視覚確認・人間閲覧用途で別途検討」** として整理
+2. README に「AI で読ませる用途は `book-ocr` を通して markdown を生成する」セクションを追加 (Phase 2)
+3. 本 issue (`#51`) を close
+
+## 再現手順
+
+```bash
+# 1. 現状 PDF (100 MB 超) を Claude Code に渡す
+#    → "PDF file exceeds maximum allowed size for text extraction (100MB)."
+
+# 2. 32 MB 以下に抜粋
+uv run --with pypdf python -c "
+from pypdf import PdfReader, PdfWriter
+reader = PdfReader('output/イシューからはじめよ.pdf')
+writer = PdfWriter()
+for i in range(20):
+    writer.add_page(reader.pages[i])
+with open('/tmp/issue_excerpt_20p.pdf', 'wb') as f:
+    writer.write(f)
+"
+#    → 13.9 MB
+
+# 3. Claude Code に渡す (poppler 未インストール環境では)
+#    → "pdftoppm is not installed. Install poppler-utils ..."
+
+# 4. book-ocr markdown は Read でそのまま開ける
+#    experiments/ocr-poc/yomitoku-out/vertical/*.md
+```


### PR DESCRIPTION
## Summary

- `output/` 配下の現状 PDF を Claude Code に渡す経路は **100 MB 上限 + poppler 依存 + 32 MB API 上限** の三重制約で事実上塞がれていると実測
- `book-ocr` の markdown は Claude Code でそのまま完璧に扱える (サイズは PDF の ~1/500、token は 1/3-1/5)
- #50 親 issue の派生子 issue (`--pdf-image-scale` / `kindle-cap-pdf-split` / JPEG quality 許容点調査) は、Claude Code 経由用途では不要と判断する材料を提供

詳細: [docs/ai-readability/2026-05-20.md](../blob/docs/ai-readability-issue-51/docs/ai-readability/2026-05-20.md)

## Test plan

- [x] `output/イシューからはじめよ.pdf` (237 MB) を `Read` で開く → 100 MB 上限エラーを再現
- [x] `pypdf` で 20p (13.9 MB) に抜粋し再度 `Read` → `pdftoppm` 未インストールエラーを観測
- [x] `experiments/ocr-poc/yomitoku-out/vertical/*.md` を `Read` で開く → 縦書き本文が綺麗に取れることを確認
- [x] 横書きサンプル (`Kaggleではじめる大規模言語モデル入門`) でも同様確認
- [x] `pre-commit` markdownlint が通る (docs のみの変更)