### PR TITLE
feat(kindle-cap): kindle-cap-pdf に --progress (tqdm) で JPEG 変換進捗 (closes #53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ output/my-book.pdf
 | `--dry-run` | | off | 1 枚だけ撮って位置確認用に保存（PDF は作らない） |
 | `--auto-stop` | | off | 連続する 2 ページが同一なら書籍末尾と判断して停止 |
 | `--pdf-jpeg-quality N` | | （未指定） | PDF 埋め込み画像を JPEG quality N (1-100) で再圧縮。未指定時は lossless PNG 埋め込み。**テキスト書籍は 80 程度推奨で PDF サイズが ~1/10 に** (issue #50) |
+| `--progress / --no-progress` | | `--no-progress` | `--pdf-jpeg-quality` 指定時の JPEG 変換ループ進捗を `tqdm` で stderr に表示。1000+ ページ書籍で「ハングしたのか」を判別できるようにする (issue #53) |
 
 ※ `--direction` または `--auto-direction` のいずれかが必須（同時指定はエラー）
 
@@ -120,6 +121,9 @@ uv run kindle-cap-pdf output/my-book
 
 # JPEG 再圧縮で PDF サイズを縮小 (テキスト書籍向け)
 uv run kindle-cap-pdf output/my-book --pdf-jpeg-quality 80
+
+# 1000+ ページ書籍は --progress で JPEG 変換中の進捗を確認
+uv run kindle-cap-pdf output/my-book --pdf-jpeg-quality 80 --progress
 ```
 
 ### book-ocr — OCR で Markdown / index.json を生成（オプション）

--- a/src/kindle_cap/cli.py
+++ b/src/kindle_cap/cli.py
@@ -65,6 +65,14 @@ def capture(
             "テキスト書籍は 80 程度推奨"
         ),
     ),
+    progress: bool = typer.Option(
+        False,
+        "--progress/--no-progress",
+        help=(
+            "--pdf-jpeg-quality 指定時の JPEG 変換ループ進捗を tqdm で stderr に"
+            "表示 (1000+ ページ書籍向け、issue #53)"
+        ),
+    ),
 ) -> None:
     if direction is not None and auto_direction:
         raise typer.BadParameter(
@@ -89,6 +97,7 @@ def capture(
             out=out,
             keep_png=keep_png,
             pdf_jpeg_quality=pdf_jpeg_quality,
+            progress=progress,
         )
     except ValueError as e:
         raise typer.BadParameter(str(e)) from e
@@ -124,6 +133,14 @@ def rebuild_pdf(
             "PDF 埋め込み画像を JPEG quality N (1-100) で再圧縮。未指定時は lossless PNG 埋め込み"
         ),
     ),
+    progress: bool = typer.Option(
+        False,
+        "--progress/--no-progress",
+        help=(
+            "--pdf-jpeg-quality 指定時の JPEG 変換ループ進捗を tqdm で stderr に"
+            "表示 (1000+ ページ書籍向け、issue #53)"
+        ),
+    ),
 ) -> None:
     pngs = sorted(directory.glob("page_*.png"), key=_page_num)
     if not pngs:
@@ -131,7 +148,7 @@ def rebuild_pdf(
         raise typer.Exit(code=1)
     out_path = directory.parent / f"{directory.name}.pdf"
     try:
-        build_pdf(pngs, out_path, jpeg_quality=pdf_jpeg_quality)
+        build_pdf(pngs, out_path, jpeg_quality=pdf_jpeg_quality, progress=progress)
     except PdfBuildError as e:
         typer.echo(f"[エラー] {e}", err=True)
         raise typer.Exit(code=1) from e

--- a/src/kindle_cap/config.py
+++ b/src/kindle_cap/config.py
@@ -27,6 +27,7 @@ class CaptureConfig:
     out: Path
     keep_png: bool
     pdf_jpeg_quality: int | None = None
+    progress: bool = False
 
     def __post_init__(self) -> None:
         if self.pages <= 0:

--- a/src/kindle_cap/orchestrator.py
+++ b/src/kindle_cap/orchestrator.py
@@ -132,7 +132,12 @@ def _capture_book(
         return
 
     pdf_path = config.out / f"{config.name}.pdf"
-    build_pdf(captured, pdf_path, jpeg_quality=config.pdf_jpeg_quality)
+    build_pdf(
+        captured,
+        pdf_path,
+        jpeg_quality=config.pdf_jpeg_quality,
+        progress=config.progress,
+    )
 
     if not config.keep_png:
         for p in captured:

--- a/src/kindle_cap/pdf.py
+++ b/src/kindle_cap/pdf.py
@@ -3,14 +3,21 @@
 `jpeg_quality` 未指定時は PNG を lossless で埋め込む (img2pdf のデフォルト動作)。
 指定時は Pillow で各 PNG を JPEG bytes に再圧縮してから埋め込み、PDF サイズを
 ~1/10 に縮小可能にする (テキスト書籍向けの trade-off オプション)。
+
+`progress=True` かつ `jpeg_quality` 指定時かつページ数 >= 2 のとき、tqdm で
+JPEG 変換ループの進捗を stderr に表示する (issue #53)。1000+ ページ書籍で
+silent な変換中にハング判定されないようにするのが目的。
 """
 
 import errno
+import sys
+from collections.abc import Iterable
 from io import BytesIO
 from pathlib import Path
 
 import img2pdf
 from PIL import Image
+from tqdm import tqdm
 
 
 class PdfBuildError(Exception):
@@ -25,11 +32,28 @@ def _png_to_jpeg_bytes(png_path: Path, quality: int) -> bytes:
         return buf.getvalue()
 
 
+def _maybe_tqdm_pngs(png_paths: list[Path], *, enabled: bool) -> Iterable[Path]:
+    """ページ数 >= 2 かつ enabled かつ stderr が tty のとき tqdm でラップ (issue #53)。
+
+    1 ページのときは進捗バーが意味を持たないため bare iterable を返す。
+    CI など非 tty の場合は disable=True で tqdm を no-op にする。"""
+    if len(png_paths) < 2 or not enabled:
+        return png_paths
+    wrapped: Iterable[Path] = tqdm(
+        png_paths,
+        desc="JPEG 変換",
+        unit="page",
+        disable=not sys.stderr.isatty(),
+    )
+    return wrapped
+
+
 def build_pdf(
     png_paths: list[Path],
     out_path: Path,
     *,
     jpeg_quality: int | None = None,
+    progress: bool = False,
 ) -> None:
     if not png_paths:
         raise ValueError("png_paths must not be empty")
@@ -41,7 +65,10 @@ def build_pdf(
     if jpeg_quality is None:
         inputs = [str(p) for p in png_paths]
     else:
-        inputs = [_png_to_jpeg_bytes(p, jpeg_quality) for p in png_paths]
+        inputs = [
+            _png_to_jpeg_bytes(p, jpeg_quality)
+            for p in _maybe_tqdm_pngs(png_paths, enabled=progress)
+        ]
 
     # outputstream を渡すことで、PDF 全体を一度メモリに展開せずに直接ファイルへ
     # 書き出せる。1000+ ページのリフロー型書籍など長尺キャプチャに対応するため

--- a/tests/unit/test_pdf.py
+++ b/tests/unit/test_pdf.py
@@ -373,3 +373,62 @@ def test_build_pdf_accepts_jpeg_quality_boundaries(tmp_path: Path) -> None:
     build_pdf([p], tmp_path / "q100.pdf", jpeg_quality=100)
     assert (tmp_path / "q1.pdf").exists()
     assert (tmp_path / "q100.pdf").exists()
+
+
+# ---------------------------------------------------------------------------
+# Progress (tqdm) option for JPEG conversion loop (issue #53)
+# ---------------------------------------------------------------------------
+
+
+def test_build_pdf_progress_default_does_not_use_tqdm(tmp_path: Path) -> None:
+    """progress=False (デフォルト) では tqdm でラップされない."""
+    pngs = [_make_rgb_png(tmp_path / f"p_{i}.png") for i in range(3)]
+    with patch("kindle_cap.pdf.tqdm") as mock_tqdm:
+        build_pdf(pngs, tmp_path / "out.pdf", jpeg_quality=80)
+    mock_tqdm.assert_not_called()
+
+
+def test_build_pdf_progress_true_wraps_jpeg_loop_with_tqdm(tmp_path: Path) -> None:
+    """progress=True + jpeg_quality 指定 + 複数ページなら tqdm が呼ばれる."""
+    pngs = [_make_rgb_png(tmp_path / f"p_{i}.png") for i in range(3)]
+    with patch("kindle_cap.pdf.tqdm", side_effect=lambda it, **kw: it) as mock_tqdm:
+        build_pdf(pngs, tmp_path / "out.pdf", jpeg_quality=80, progress=True)
+    mock_tqdm.assert_called_once()
+    # tqdm に渡される最初の引数は png_paths リスト
+    args, _ = mock_tqdm.call_args
+    assert args[0] == pngs
+
+
+def test_build_pdf_progress_true_without_jpeg_quality_does_not_use_tqdm(
+    tmp_path: Path,
+) -> None:
+    """jpeg_quality=None のときは JPEG ループがないため progress=True でも tqdm 不要."""
+    pngs = [_make_rgb_png(tmp_path / f"p_{i}.png") for i in range(3)]
+    with patch("kindle_cap.pdf.tqdm") as mock_tqdm:
+        build_pdf(pngs, tmp_path / "out.pdf", progress=True)
+    mock_tqdm.assert_not_called()
+
+
+def test_build_pdf_progress_true_with_single_png_does_not_use_tqdm(
+    tmp_path: Path,
+) -> None:
+    """1 ページのときは進捗バーが意味を持たないので tqdm を呼ばない."""
+    p = _make_rgb_png(tmp_path / "only.png")
+    with patch("kindle_cap.pdf.tqdm") as mock_tqdm:
+        build_pdf([p], tmp_path / "out.pdf", jpeg_quality=80, progress=True)
+    mock_tqdm.assert_not_called()
+
+
+def test_build_pdf_progress_disables_tqdm_when_stderr_not_tty(
+    tmp_path: Path,
+) -> None:
+    """非 tty (CI 等) では tqdm を呼ぶが disable=True を渡す."""
+    pngs = [_make_rgb_png(tmp_path / f"p_{i}.png") for i in range(3)]
+    with (
+        patch("kindle_cap.pdf.sys.stderr.isatty", return_value=False),
+        patch("kindle_cap.pdf.tqdm", side_effect=lambda it, **kw: it) as mock_tqdm,
+    ):
+        build_pdf(pngs, tmp_path / "out.pdf", jpeg_quality=80, progress=True)
+    mock_tqdm.assert_called_once()
+    _, kwargs = mock_tqdm.call_args
+    assert kwargs.get("disable") is True


### PR DESCRIPTION
## Summary

- `build_pdf(progress: bool=False)` を追加し、`jpeg_quality` 指定時の JPEG 変換 list comprehension を tqdm でラップ
- `book-ocr` の `_maybe_tqdm` パターン (issue #38 / PR #46) をそのまま引き写し
- `kindle-cap` と `kindle-cap-pdf` 双方に `--progress/--no-progress` フラグ
- デフォルト off。短い書籍で煩わしくならず、CI / 非 tty では `disable=True` で no-op

## 設計判断

- **`jpeg_quality=None` のときは tqdm 不要** — その場合は img2pdf が直接 PNG パスを処理し、Python 側で JPEG 変換ループは存在しないので進捗バーが意味を持たない
- **1 ページのときは tqdm 不要** — `len(png_paths) < 2` で bare iterable を返す
- **非 tty (CI 等) では `disable=True`** — `sys.stderr.isatty()` を内部で参照

## Test plan

- [x] `pytest tests/unit/test_pdf.py` 全 33 pass
- [x] `pytest` 全 337 pass / 16 skipped
- [x] `ruff check src/ tests/` clean
- [x] `mypy src/` clean
- [x] `kindle-cap-pdf --help` で `--progress / --no-progress` が表示されることを確認
- [x] README にオプション説明と使用例を追加

## Closes

- closes #53