### PR TITLE
feat(book-ocr): ディスク容量 preflight チェック (closes #48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ output/my-book.pdf                # 既存。視覚確認用
 | `--end-page M` | None | OCR 終了ページ番号 (1-indexed inclusive、省略時は最後まで、issue #39) |
 | `--progress / --no-progress` | `--progress` | chunked 実行時に tqdm で chunk 進捗を stderr に表示 (issue #38) |
 | `--skip-existing` | off | 既存 `pages/page_NNN.md` があるページは OCR をスキップ (issue #41)。失敗後の再走を高速化 |
+| `--ignore-disk-check` | off | 起動時のディスク容量 preflight をバイパス (issue #48)。デフォルトは入力 PNG × 1.5 マージンで out_dir / tempdir 残量を確認し、不足なら exit 1 |
 
 #### 性能の目安（Apple Silicon MPS）
 

--- a/src/book_ocr/cli.py
+++ b/src/book_ocr/cli.py
@@ -15,6 +15,7 @@ from book_ocr.engines.yomitoku import YomiTokuEngine
 from book_ocr.exporters.book_md import render_book_md
 from book_ocr.exporters.json_index import render_index
 from book_ocr.models import BookMetadata, PageText
+from book_ocr.preflight import PreflightError, check_disk_space
 from book_ocr.protocols import OCREngine
 
 # render_page_md と対称な逆解析: 先頭の "<!-- page:NNN -->\n\n" を取り除く
@@ -35,6 +36,7 @@ def run_ocr_pipeline(
     end_page: int | None = None,
     progress: bool = True,
     skip_existing: bool = False,
+    ignore_disk_check: bool = False,
 ) -> Path:
     """指定した book_dir 内の page_*.png を OCR して Markdown / index.json を出力する.
 
@@ -61,6 +63,9 @@ def run_ocr_pipeline(
 
     title = name or book_dir.name
     out_dir = out or book_dir
+
+    if not ignore_disk_check:
+        check_disk_space(pngs=pngs, out_dir=out_dir, chunk_size=chunk_size)
 
     engine = engine or YomiTokuEngine(
         device=device,
@@ -190,6 +195,14 @@ def ocr(
             "失敗後の再走で chunk 単位 retry を高速化する。空ファイルは missing 扱い。"
         ),
     ),
+    ignore_disk_check: bool = typer.Option(
+        False,
+        "--ignore-disk-check",
+        help=(
+            "起動時のディスク容量 preflight をバイパスする (issue #48)。"
+            "デフォルトでは入力 PNG × 1.5 のマージンで out_dir / tempdir の残量を確認する。"
+        ),
+    ),
 ) -> None:
     """指定した book_dir 内の page_*.png を OCR して Markdown / index.json を生成する."""
     try:
@@ -206,12 +219,16 @@ def ocr(
             end_page=end_page,
             progress=progress,
             skip_existing=skip_existing,
+            ignore_disk_check=ignore_disk_check,
         )
     except FileNotFoundError as e:
         typer.echo(str(e), err=True)
         raise typer.Exit(1) from e
     except ValueError as e:
         typer.echo(str(e), err=True)
+        raise typer.Exit(1) from e
+    except PreflightError as e:
+        typer.echo(f"[エラー] {e}", err=True)
         raise typer.Exit(1) from e
     typer.echo(f"OCR complete: {out_path}")
 

--- a/src/book_ocr/preflight.py
+++ b/src/book_ocr/preflight.py
@@ -1,0 +1,89 @@
+"""book-ocr のディスク容量 preflight チェック (issue #48).
+
+OCR 実行前に出力ディレクトリと tempdir 双方の残量を確認し、yomitoku が
+中間 jpg を吐く分も含めて不足なら起動を止める。実 OCR 開始後の途中失敗
+(chunk 1 で全部ロス) を予防する。
+
+`kindle_cap/preflight.py` の構造 (PreflightError + checker 関数) を踏襲。
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+
+
+class PreflightError(RuntimeError):
+    """ディスク容量不足など、起動前のチェックで検出した障害を表す."""
+
+
+# yomitoku は入力 PNG を tempdir に symlink/コピーし、内部で中間 jpg を生成する。
+# 入力サイズ × 1.5 倍をマージン込みの上限と見積もる。
+_TEMPFILE_MARGIN = 1.5
+
+
+def estimate_required_bytes(pngs: list[Path], chunk_size: int | None) -> int:
+    """OCR 中に同時存在し得る一時データのサイズ見積もり (bytes).
+
+    `chunk_size` が指定されていれば 1 chunk 分のみが同時に展開される (issue #36)。
+    省略時は全 PNG 分の容量を要求する。
+    """
+    if not pngs:
+        return 0
+    target = pngs if chunk_size is None else pngs[:chunk_size]
+    total = sum(p.stat().st_size for p in target)
+    return int(total * _TEMPFILE_MARGIN)
+
+
+def _resolve_existing_ancestor(path: Path) -> Path:
+    """指定パスがまだ存在しない場合、最初に存在する祖先まで遡る."""
+    probe = path
+    while not probe.exists():
+        if probe.parent == probe:
+            return probe
+        probe = probe.parent
+    return probe
+
+
+def check_disk_space(
+    *,
+    pngs: list[Path],
+    out_dir: Path,
+    chunk_size: int | None,
+    tempdir: Path | None = None,
+    disk_usage_fn: Callable[[Path], shutil._ntuple_diskusage] = shutil.disk_usage,
+) -> None:
+    """out_dir と tempdir 双方のマウントで残量チェック。不足なら PreflightError.
+
+    tempdir を省略時は `tempfile.gettempdir()` を使う。同一マウントなら
+    重複チェックは省略する (st_dev で判定)。
+    """
+    required = estimate_required_bytes(pngs, chunk_size)
+    if required == 0:
+        return
+
+    tmp = tempdir or Path(tempfile.gettempdir())
+    seen_devices: set[int] = set()
+    for target in (out_dir, tmp):
+        probe = _resolve_existing_ancestor(target)
+        try:
+            device_id = probe.stat().st_dev
+        except OSError:
+            continue
+        if device_id in seen_devices:
+            continue
+        seen_devices.add(device_id)
+        try:
+            usage = disk_usage_fn(probe)
+        except OSError:
+            continue
+        if usage.free < required:
+            raise PreflightError(
+                f"ディスク容量不足: {target} を含むパーティションに "
+                f"約 {required / 1024 / 1024:.0f} MB 必要ですが "
+                f"残り {usage.free / 1024 / 1024:.0f} MB しかありません "
+                f"({len(pngs)} ページ × {_TEMPFILE_MARGIN} マージン、chunk_size={chunk_size})。"
+                " 容量を確保するか `--ignore-disk-check` でバイパスしてください。"
+            )

--- a/tests/unit/test_book_ocr_preflight.py
+++ b/tests/unit/test_book_ocr_preflight.py
@@ -1,0 +1,276 @@
+"""book_ocr.preflight のテスト (issue #48)."""
+
+from __future__ import annotations
+
+from collections import namedtuple
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from book_ocr.preflight import (
+    PreflightError,
+    check_disk_space,
+    estimate_required_bytes,
+)
+
+_DiskUsage = namedtuple("_DiskUsage", ["total", "used", "free"])
+
+
+def _png(path: Path, size_bytes: int = 1024) -> Path:
+    path.write_bytes(b"\x00" * size_bytes)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# estimate_required_bytes
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_empty_returns_zero() -> None:
+    assert estimate_required_bytes([], chunk_size=None) == 0
+
+
+def test_estimate_uses_15x_margin(tmp_path: Path) -> None:
+    p = _png(tmp_path / "page_001.png", size_bytes=1000)
+    assert estimate_required_bytes([p], chunk_size=None) == 1500
+
+
+def test_estimate_chunk_size_only_counts_first_chunk(tmp_path: Path) -> None:
+    """chunk_size 指定時は最初の chunk 分だけを集計対象に含める."""
+    pngs = [_png(tmp_path / f"p_{i}.png", size_bytes=1000) for i in range(10)]
+    assert estimate_required_bytes(pngs, chunk_size=3) == int(3 * 1000 * 1.5)
+
+
+def test_estimate_chunk_size_none_counts_all(tmp_path: Path) -> None:
+    pngs = [_png(tmp_path / f"p_{i}.png", size_bytes=1000) for i in range(5)]
+    assert estimate_required_bytes(pngs, chunk_size=None) == int(5 * 1000 * 1.5)
+
+
+def test_estimate_chunk_size_larger_than_pages_uses_all(tmp_path: Path) -> None:
+    pngs = [_png(tmp_path / f"p_{i}.png", size_bytes=1000) for i in range(3)]
+    # chunk_size=10 だが、pngs[:10] は 3 要素しかない
+    assert estimate_required_bytes(pngs, chunk_size=10) == int(3 * 1000 * 1.5)
+
+
+# ---------------------------------------------------------------------------
+# check_disk_space
+# ---------------------------------------------------------------------------
+
+
+def test_check_disk_space_passes_when_free_is_sufficient(tmp_path: Path) -> None:
+    pngs = [_png(tmp_path / "p_001.png", size_bytes=1000)]
+    fake = lambda _: _DiskUsage(total=10_000_000, used=0, free=10_000_000)  # noqa: E731
+    # required ≒ 1500 bytes、free = 10 MB なので問題なし
+    check_disk_space(
+        pngs=pngs,
+        out_dir=tmp_path,
+        chunk_size=None,
+        tempdir=tmp_path,
+        disk_usage_fn=fake,
+    )
+
+
+def test_check_disk_space_raises_when_free_is_insufficient(tmp_path: Path) -> None:
+    pngs = [_png(tmp_path / "p_001.png", size_bytes=10 * 1024 * 1024)]
+    # 必要 ~15 MB、free 5 MB → 不足
+    fake = lambda _: _DiskUsage(total=100_000_000, used=0, free=5 * 1024 * 1024)  # noqa: E731
+    with pytest.raises(PreflightError, match="ディスク容量不足"):
+        check_disk_space(
+            pngs=pngs,
+            out_dir=tmp_path,
+            chunk_size=None,
+            tempdir=tmp_path,
+            disk_usage_fn=fake,
+        )
+
+
+def test_check_disk_space_message_includes_required_and_free(tmp_path: Path) -> None:
+    pngs = [_png(tmp_path / "p_001.png", size_bytes=10 * 1024 * 1024)]
+    fake = lambda _: _DiskUsage(total=100_000_000, used=0, free=5 * 1024 * 1024)  # noqa: E731
+    with pytest.raises(PreflightError) as exc_info:
+        check_disk_space(
+            pngs=pngs,
+            out_dir=tmp_path,
+            chunk_size=None,
+            tempdir=tmp_path,
+            disk_usage_fn=fake,
+        )
+    msg = str(exc_info.value)
+    assert "MB" in msg
+    assert "1 ページ" in msg
+    assert "--ignore-disk-check" in msg
+
+
+def test_check_disk_space_empty_pngs_is_noop(tmp_path: Path) -> None:
+    called: list[Path] = []
+
+    def fake(p: Path) -> _DiskUsage:
+        called.append(p)
+        return _DiskUsage(total=0, used=0, free=0)
+
+    check_disk_space(
+        pngs=[],
+        out_dir=tmp_path,
+        chunk_size=None,
+        tempdir=tmp_path,
+        disk_usage_fn=fake,
+    )
+    # required=0 のため disk_usage_fn は呼ばれない
+    assert called == []
+
+
+def test_check_disk_space_chunk_size_relaxes_requirement(tmp_path: Path) -> None:
+    """chunk_size 指定時は 1 chunk 分しか見ないので、足りる残量が小さくて済む."""
+    pngs = [_png(tmp_path / f"p_{i:03d}.png", size_bytes=10 * 1024 * 1024) for i in range(10)]
+    # 必要 (chunk_size=1) ≒ 15 MB、free 20 MB → 通る
+    fake = lambda _: _DiskUsage(total=100_000_000, used=0, free=20 * 1024 * 1024)  # noqa: E731
+    check_disk_space(
+        pngs=pngs,
+        out_dir=tmp_path,
+        chunk_size=1,
+        tempdir=tmp_path,
+        disk_usage_fn=fake,
+    )
+
+
+def test_check_disk_space_chunk_size_none_fails_when_total_too_large(tmp_path: Path) -> None:
+    """chunk_size=None だと全 PNG 分要求するため、同じ free でも足りないことがある."""
+    pngs = [_png(tmp_path / f"p_{i:03d}.png", size_bytes=10 * 1024 * 1024) for i in range(10)]
+    # 必要 ≒ 150 MB、free 20 MB → 不足
+    fake = lambda _: _DiskUsage(total=200_000_000, used=0, free=20 * 1024 * 1024)  # noqa: E731
+    with pytest.raises(PreflightError):
+        check_disk_space(
+            pngs=pngs,
+            out_dir=tmp_path,
+            chunk_size=None,
+            tempdir=tmp_path,
+            disk_usage_fn=fake,
+        )
+
+
+def test_check_disk_space_resolves_nonexistent_out_dir_to_parent(tmp_path: Path) -> None:
+    """まだ作成されていない out_dir でも、祖先に遡って残量を確認できる."""
+    pngs = [_png(tmp_path / "p_001.png", size_bytes=1000)]
+    not_yet = tmp_path / "does" / "not" / "exist"
+    seen: list[Path] = []
+
+    def fake(p: Path) -> _DiskUsage:
+        seen.append(p)
+        return _DiskUsage(total=10_000_000, used=0, free=10_000_000)
+
+    check_disk_space(
+        pngs=pngs,
+        out_dir=not_yet,
+        chunk_size=None,
+        tempdir=tmp_path,
+        disk_usage_fn=fake,
+    )
+    # 既存祖先 (tmp_path 配下のどこか) が disk_usage に渡されている
+    assert any(str(tmp_path) in str(s) for s in seen)
+
+
+def test_check_disk_space_skips_same_device(tmp_path: Path) -> None:
+    """out_dir と tempdir が同一マウントなら 2 回チェックしない."""
+    pngs = [_png(tmp_path / "p_001.png", size_bytes=1000)]
+    call_count = 0
+
+    def fake(_: Path) -> _DiskUsage:
+        nonlocal call_count
+        call_count += 1
+        return _DiskUsage(total=10_000_000, used=0, free=10_000_000)
+
+    check_disk_space(
+        pngs=pngs,
+        out_dir=tmp_path,
+        chunk_size=None,
+        tempdir=tmp_path,
+        disk_usage_fn=fake,
+    )
+    assert call_count == 1
+
+
+def test_check_disk_space_uses_system_tempdir_when_tempdir_is_none(tmp_path: Path) -> None:
+    """tempdir=None なら tempfile.gettempdir() を参照する."""
+    pngs = [_png(tmp_path / "p_001.png", size_bytes=1000)]
+    seen: list[Path] = []
+
+    def fake(p: Path) -> _DiskUsage:
+        seen.append(p)
+        return _DiskUsage(total=10_000_000, used=0, free=10_000_000)
+
+    check_disk_space(
+        pngs=pngs,
+        out_dir=tmp_path,
+        chunk_size=None,
+        tempdir=None,
+        disk_usage_fn=fake,
+    )
+    # tmp_path と system tempdir のどちらかが呼ばれる (同一マウントの可能性もある)
+    assert len(seen) >= 1
+
+
+def test_check_disk_space_uses_real_disk_usage_by_default(tmp_path: Path) -> None:
+    """`disk_usage_fn` を渡さない場合は shutil.disk_usage を使う."""
+    pngs = [_png(tmp_path / "p_001.png", size_bytes=1)]
+    # 実 disk_usage で通る (普段の開発機なら数 bytes は十分余る)
+    check_disk_space(pngs=pngs, out_dir=tmp_path, chunk_size=None, tempdir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# cli 統合: --ignore-disk-check / preflight 失敗の伝搬
+# ---------------------------------------------------------------------------
+
+
+def _make_book_dir(tmp_path: Path, n_pages: int = 2) -> Path:
+    book = tmp_path / "my-book"
+    book.mkdir()
+    for i in range(1, n_pages + 1):
+        (book / f"page_{i:03d}.png").write_bytes(b"\x00" * 1024)
+    return book
+
+
+def test_run_ocr_pipeline_calls_check_disk_space_by_default(tmp_path: Path) -> None:
+    """run_ocr_pipeline は preflight を呼ぶ (ignore_disk_check=False がデフォルト)."""
+    from book_ocr.cli import run_ocr_pipeline
+
+    book = _make_book_dir(tmp_path, n_pages=2)
+
+    with patch("book_ocr.cli.check_disk_space") as mock_check:
+        # FakeEngine 注入 (yomitoku を呼ばない)
+        from tests.unit.test_book_ocr_cli import FakeEngine
+
+        run_ocr_pipeline(book_dir=book, engine=FakeEngine())
+
+    mock_check.assert_called_once()
+
+
+def test_run_ocr_pipeline_skips_check_when_ignore_flag_set(tmp_path: Path) -> None:
+    from book_ocr.cli import run_ocr_pipeline
+
+    book = _make_book_dir(tmp_path, n_pages=2)
+
+    with patch("book_ocr.cli.check_disk_space") as mock_check:
+        from tests.unit.test_book_ocr_cli import FakeEngine
+
+        run_ocr_pipeline(book_dir=book, engine=FakeEngine(), ignore_disk_check=True)
+
+    mock_check.assert_not_called()
+
+
+def test_run_ocr_pipeline_propagates_preflight_error(tmp_path: Path) -> None:
+    """check_disk_space が PreflightError を投げたら run_ocr_pipeline に伝搬する."""
+    from book_ocr.cli import run_ocr_pipeline
+
+    book = _make_book_dir(tmp_path, n_pages=2)
+
+    with (
+        patch(
+            "book_ocr.cli.check_disk_space",
+            side_effect=PreflightError("disk full"),
+        ),
+        pytest.raises(PreflightError, match="disk full"),
+    ):
+        from tests.unit.test_book_ocr_cli import FakeEngine
+
+        run_ocr_pipeline(book_dir=book, engine=FakeEngine())


### PR DESCRIPTION
## Summary

- 新規 `src/book_ocr/preflight.py` で `check_disk_space` + `estimate_required_bytes` を実装
- `run_ocr_pipeline` 冒頭でディスク残量を確認し、不足なら `PreflightError` で起動を止める
- `--ignore-disk-check` フラグでバイパス可能

## 設計判断

- **見積もり: 入力 PNG × 1.5 マージン** — yomitoku が tempdir に中間 jpg を吐く分を想定
- **`chunk_size` 指定時は 1 chunk 分のみを評価** — 同時に展開されるサイズが小さいため
- **`out_dir` と `tempdir` 両方のマウントをチェック** — `st_dev` で同一マウントなら重複チェック省略
- **`out_dir` がまだ存在しない場合は祖先まで遡って `disk_usage` を取る** — 初回実行時にも動くように
- エラーメッセージに必要 MB / 残 MB / ページ数 / chunk_size / `--ignore-disk-check` ヒントを全部入れる

## Test plan

- [x] `pytest tests/unit/test_book_ocr_preflight.py` 全 18 pass
- [x] `pytest` 全 355 pass / 16 skipped
- [x] `ruff check` clean
- [x] `mypy src/` clean
- [x] `book-ocr --help` で `--ignore-disk-check` が表示されることを確認
- [x] README にオプション説明追加

## Closes

- closes #48