### PR TITLE
fix(kindle-cap): --auto-direction で表紙ページが出力に残るよう修正 (closes #59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `--auto-direction` 経路で起点フレーム（表紙）が出力 PNG / PDF に含まれず欠落していた不具合を修正。`detect_direction()` が表紙を `_origin.png` として撮影したあと `finally` で削除し、probe direction で進めた後のフレームを `page_001.png..page_003.png` として保存していたのが原因。表紙を `page_001.png` として保持し、probe を `page_002.png..page_004.png` に変更。fallback 経路 (probe 無反応 → 逆方向 verify) でも `page_001.png` を表紙、`page_002.png` を verify として残す。「`page_001.png` のハッシュが起点フレームと一致する」という振る舞いベースのテストが欠落していたためレビューを素通りしていた点もテストで補強した (issue #59)
+
 ## [0.2.0] - 2026-05-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ output/my-book.pdf
 |---|---|---|---|
 | `--pages N` | ✓ | — | 撮影ページ数の上限 |
 | `--direction rtl\|ltr` | ※ | — | `rtl`=右綴じ（右矢印で次ページ）、`ltr`=左綴じ（左矢印で次ページ） |
-| `--auto-direction` | ※ | off | 表紙起点で direction を試写判定。試写は本番に流用（重複撮影なし） |
+| `--auto-direction` | ※ | off | 表紙起点で direction を試写判定。**起点フレーム（表紙）は `page_001.png` として保存し**、試写は `page_002.png` 以降に流用（重複撮影なし） |
 | `--name NAME` | | （対話プロンプト） | 出力ディレクトリ名 |
 | `--wait SEC` | | `1.0` | ページ送り後の待機秒（重い書籍は `1.5` 推奨） |
 | `--out PATH` | | `./output` | 出力先 |

--- a/docs/superpowers/specs/2026-04-25-kindle-screenshot-design.md
+++ b/docs/superpowers/specs/2026-04-25-kindle-screenshot-design.md
@@ -269,7 +269,7 @@ CI ではユニットのみ。integration はローカル手動。
 - 自動トリミング（実コンテンツ領域の検出）
 - 見開き分割（左右ページの分離）
 - ライブラリ画面からの一括キャプチャ（PR #4 で `--from-library` として試行 → 実機検証で Kindle for Mac の制約により断念。再挑戦するなら GUI オートメーション前提の別アプローチが必要）
-- `--auto-direction`：最初の数ページで矢印キーを試して進む方を採用（Kindle for Mac の direction が紙の綴じ方向と一致しないケースがあるため）
+- `--auto-direction`：最初の数ページで矢印キーを試して進む方を採用（Kindle for Mac の direction が紙の綴じ方向と一致しないケースがあるため）→ 実装済み (issue #15)。`detect_direction()` が起点フレームを `page_001.png` として保持し、probe direction で進めた後のフレームを `page_002..page_004.png` として撮影、本撮影に流用する。表紙保持は issue #59 で修正
 
 ## 12. 実装順序の推奨
 

--- a/src/kindle_cap/orchestrator.py
+++ b/src/kindle_cap/orchestrator.py
@@ -32,7 +32,7 @@ def run(
         out_dir.mkdir(parents=True, exist_ok=True)
         _purge_old_pages(out_dir)
 
-        resolved_direction, probe_pngs = detect_direction(
+        resolved_direction, initial_pngs = detect_direction(
             out_dir=out_dir,
             geom_provider=get_window_geometry,
             activator=activate_kindle,
@@ -43,16 +43,13 @@ def run(
         )
         resolved_config = dataclasses.replace(config, direction=resolved_direction)
 
-        if probe_pngs:
-            seed_hashes = [_image_hash(p) for p in probe_pngs]
-            _capture_book(
-                resolved_config,
-                auto_stop=auto_stop,
-                start_index=len(probe_pngs) + 1,
-                seed_hashes=seed_hashes,
-            )
-        else:
-            _capture_book(resolved_config, auto_stop=auto_stop)
+        seed_hashes = [_image_hash(p) for p in initial_pngs]
+        _capture_book(
+            resolved_config,
+            auto_stop=auto_stop,
+            start_index=len(initial_pngs) + 1,
+            seed_hashes=seed_hashes,
+        )
         return
 
     if config.direction is None:

--- a/src/kindle_cap/preflight.py
+++ b/src/kindle_cap/preflight.py
@@ -91,36 +91,39 @@ def detect_direction(
     """表紙起点で direction を判定する。
 
     アルゴリズム:
-        1. 起点フレーム (_origin.png) を撮影
-        2. probe_direction を probe_count 回送って page_001..N.png に撮影
-        3. 起点と最終試写を MD5 比較:
-           - 変化あり → (probe_direction, 試写リスト) を返す（試写は本番採用）
-           - 変化なし → 試写を全削除し、逆方向で 1 回だけ verify
-              - verify で変化あり → (other_direction, []) を返す（本番は page_001 から）
-              - verify でも変化なし → PreflightError
+        1. 起点フレーム（表紙）を page_001.png として撮影
+        2. probe_direction を probe_count 回送って page_002..page_{probe_count+1}.png に撮影
+        3. 表紙と最終試写を MD5 比較:
+           - 変化あり → (probe_direction, [page_001, ..., page_{probe_count+1}]) を返す
+              （表紙＋試写を本番採用）
+           - 変化なし → 試写を全削除し、逆方向で 1 回だけ verify を page_002.png に撮る
+              - verify で変化あり → (other_direction, [page_001, page_002]) を返す
+              - verify でも変化なし → page_001 / page_002 を削除して PreflightError
 
-    試写は実 PNG として out_dir に書き出されるため、成功時はそのまま本番流用できる。
-    依存性注入: keys.send_next_page / capture_rect 等を Callable で受ける。
+    返り値の list[Path] は常に「最終出力に含めるべき初期ページ群」を意味し、
+    先頭が表紙 (page_001.png)、後続が probe direction で進めた後のフレーム。
+    呼び出し側 _capture_book に start_index = len(...) + 1 / seed_hashes として渡す。
     """
     activator()
     geom = geom_provider()
-    origin_path = out_dir / "_origin.png"
+    cover_path = out_dir / "page_001.png"
+    capturer(geom, cover_path)
+    cover_hash = _md5(cover_path)
+    keep_cover = False
     try:
-        capturer(geom, origin_path)
-        origin_hash = _md5(origin_path)
-
         probe_pngs: list[Path] = []
         for i in range(1, probe_count + 1):
             sender(probe_direction)
             sleeper(wait)
             activator()
             geom = geom_provider()
-            png = out_dir / f"page_{i:03d}.png"
+            png = out_dir / f"page_{i + 1:03d}.png"
             capturer(geom, png)
             probe_pngs.append(png)
 
-        if _md5(probe_pngs[-1]) != origin_hash:
-            return probe_direction, probe_pngs
+        if _md5(probe_pngs[-1]) != cover_hash:
+            keep_cover = True
+            return probe_direction, [cover_path, *probe_pngs]
 
         # probe 無反応 → 試写を全削除して逆方向で確認
         for p in probe_pngs:
@@ -130,17 +133,17 @@ def detect_direction(
         sleeper(wait)
         activator()
         geom = geom_provider()
-        verify_path = out_dir / "_verify.png"
-        try:
-            capturer(geom, verify_path)
-            if _md5(verify_path) != origin_hash:
-                return other, []
-        finally:
-            verify_path.unlink(missing_ok=True)
+        verify_path = out_dir / "page_002.png"
+        capturer(geom, verify_path)
+        if _md5(verify_path) != cover_hash:
+            keep_cover = True
+            return other, [cover_path, verify_path]
+        verify_path.unlink(missing_ok=True)
 
         raise PreflightError(
             "両方向ともページが進みません。"
             "Kindle にフォーカスがないか、書籍が 1 ページしかない可能性があります。"
         )
     finally:
-        origin_path.unlink(missing_ok=True)
+        if not keep_cover:
+            cover_path.unlink(missing_ok=True)

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -667,6 +667,85 @@ def test_run_with_direction_none_and_auto_direction_false_raises(
         run(config, auto_direction=False)
 
 
+# ---------------------------------------------------------------------------
+# 振る舞いベース: --auto-direction で表紙ページが page_001.png として残ること (issue #59)
+# ---------------------------------------------------------------------------
+
+
+def _detect_stub_with_cover(direction: Direction, num_pngs: int, cover_bytes: bytes) -> Any:
+    """detect_direction の挙動を模倣: page_001=表紙、page_002..N が probe 後のページ。"""
+
+    def _stub(*, out_dir: Path, **_kwargs: Any) -> tuple[Direction, list[Path]]:
+        pngs = []
+        cover = out_dir / "page_001.png"
+        cover.write_bytes(cover_bytes)
+        pngs.append(cover)
+        for i in range(2, num_pngs + 1):
+            p = out_dir / f"page_{i:03d}.png"
+            p.write_bytes(f"probe-{i}".encode())
+            pngs.append(p)
+        return (direction, pngs)
+
+    return _stub
+
+
+@patch("kindle_cap.orchestrator.build_pdf")
+@patch("kindle_cap.orchestrator.send_next_page")
+@patch("kindle_cap.orchestrator.capture_rect")
+@patch("kindle_cap.orchestrator.get_window_geometry")
+@patch("kindle_cap.orchestrator.activate_kindle")
+@patch("kindle_cap.orchestrator.preflight")
+@patch("kindle_cap.orchestrator.detect_direction")
+def test_run_auto_direction_pdf_includes_cover_as_first_page(
+    mock_detect: MagicMock,
+    mock_pre: MagicMock,
+    mock_act: MagicMock,
+    mock_geom: MagicMock,
+    mock_cap: MagicMock,
+    mock_send: MagicMock,
+    mock_pdf: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """auto_direction 成功時、PDF 入力の先頭は detect が撮った表紙 (page_001.png)"""
+    mock_geom.return_value = _GEOM
+    mock_detect.side_effect = _detect_stub_with_cover(Direction.RTL, 4, b"COVER")
+    mock_cap.side_effect = lambda g, p: p.write_bytes(b"new")
+    config = _config(tmp_path, pages=6, direction=None)
+    run(config, auto_direction=True)
+    pdf_inputs = mock_pdf.call_args[0][0]
+    assert pdf_inputs[0].name == "page_001.png"
+    assert pdf_inputs[0].read_bytes() == b"COVER"
+
+
+@patch("kindle_cap.orchestrator.build_pdf")
+@patch("kindle_cap.orchestrator.send_next_page")
+@patch("kindle_cap.orchestrator.capture_rect")
+@patch("kindle_cap.orchestrator.get_window_geometry")
+@patch("kindle_cap.orchestrator.activate_kindle")
+@patch("kindle_cap.orchestrator.preflight")
+@patch("kindle_cap.orchestrator.detect_direction")
+def test_run_auto_direction_fallback_pdf_includes_cover_as_first_page(
+    mock_detect: MagicMock,
+    mock_pre: MagicMock,
+    mock_act: MagicMock,
+    mock_geom: MagicMock,
+    mock_cap: MagicMock,
+    mock_send: MagicMock,
+    mock_pdf: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """auto_direction fallback (probe 無反応) でも表紙が PDF の先頭に含まれる"""
+    mock_geom.return_value = _GEOM
+    # detect が [cover, verify] の 2 枚を返す（fallback パス）
+    mock_detect.side_effect = _detect_stub_with_cover(Direction.LTR, 2, b"COVER")
+    mock_cap.side_effect = lambda g, p: p.write_bytes(b"new")
+    config = _config(tmp_path, pages=4, direction=None)
+    run(config, auto_direction=True)
+    pdf_inputs = mock_pdf.call_args[0][0]
+    assert pdf_inputs[0].name == "page_001.png"
+    assert pdf_inputs[0].read_bytes() == b"COVER"
+
+
 @patch("kindle_cap.orchestrator.capture_rect")
 @patch("kindle_cap.orchestrator.get_window_geometry")
 @patch("kindle_cap.orchestrator.activate_kindle")

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -200,28 +200,17 @@ def _detect_kwargs(tmp_path: Path, **overrides: Any) -> dict[str, Any]:
 def test_detect_direction_returns_probe_direction_when_pages_advance(
     tmp_path: Path,
 ) -> None:
-    """起点 != 試写3 のシーケンス → probe_direction (RTL) を返し、試写を本番採用"""
+    """起点 != 試写3 → probe_direction (RTL) を返し、表紙＋試写を本番採用"""
     cap = _capturer_writing_seq([b"origin", b"p1", b"p2", b"p3"])
     direction, pngs = detect_direction(**_detect_kwargs(tmp_path, capturer=cap))
     assert direction is Direction.RTL
-    assert [p.name for p in pngs] == ["page_001.png", "page_002.png", "page_003.png"]
+    assert [p.name for p in pngs] == [
+        "page_001.png",
+        "page_002.png",
+        "page_003.png",
+        "page_004.png",
+    ]
     assert all(p.exists() for p in pngs)
-
-
-def test_detect_direction_returns_probe_pngs_named_page_001_to_003(
-    tmp_path: Path,
-) -> None:
-    cap = _capturer_writing_seq([b"o", b"a", b"b", b"c"])
-    _, pngs = detect_direction(**_detect_kwargs(tmp_path, capturer=cap))
-    assert pngs[0] == tmp_path / "page_001.png"
-    assert pngs[1] == tmp_path / "page_002.png"
-    assert pngs[2] == tmp_path / "page_003.png"
-
-
-def test_detect_direction_unlinks_origin_png_on_success(tmp_path: Path) -> None:
-    cap = _capturer_writing_seq([b"o", b"a", b"b", b"c"])
-    detect_direction(**_detect_kwargs(tmp_path, capturer=cap))
-    assert not (tmp_path / "_origin.png").exists()
 
 
 def test_detect_direction_calls_sender_three_times_for_probe(tmp_path: Path) -> None:
@@ -239,7 +228,7 @@ def test_detect_direction_default_probe_direction_is_rtl(tmp_path: Path) -> None
 
 
 def test_detect_direction_uses_probe_count_parameter(tmp_path: Path) -> None:
-    """probe_count=5 を渡せば 5 枚撮る。"""
+    """probe_count=5 を渡せば 5 回送信し、表紙＋5 枚 = 6 枚を返す。"""
     cap = _capturer_writing_seq([b"o", b"1", b"2", b"3", b"4", b"5"])
     sender = MagicMock()
     direction, pngs = detect_direction(
@@ -247,33 +236,34 @@ def test_detect_direction_uses_probe_count_parameter(tmp_path: Path) -> None:
         probe_count=5,
     )
     assert direction is Direction.RTL
-    assert len(pngs) == 5
+    assert len(pngs) == 6  # 表紙 (page_001) + probe 5 枚 (page_002..006)
     assert sender.call_count == 5
 
 
 def test_detect_direction_falls_back_to_other_direction_when_no_advance(
     tmp_path: Path,
 ) -> None:
-    """起点 == 試写3（無反応）、verify では変化あり → other_direction を返し試写は破棄。"""
+    """起点 == 試写3（無反応）、verify では変化あり → other_direction を返す。
+    戻り値は [表紙=page_001, verify=page_002] の 2 枚。"""
     cap = _capturer_writing_seq([b"same", b"same", b"same", b"same", b"changed"])
     sender = MagicMock()
     direction, pngs = detect_direction(
         **_detect_kwargs(tmp_path, capturer=cap, sender=sender),
     )
     assert direction is Direction.LTR
-    assert pngs == []
+    assert [p.name for p in pngs] == ["page_001.png", "page_002.png"]
     assert sender.call_args_list[-1].args[0] is Direction.LTR
 
 
-def test_detect_direction_unlinks_probe_pngs_on_fallback(tmp_path: Path) -> None:
-    """fallback 時、試写 PNG / _origin / _verify がすべて削除される。"""
+def test_detect_direction_discards_probe_pngs_on_fallback(tmp_path: Path) -> None:
+    """fallback 時、probe で撮った中間ページ (page_003/004) は削除されるが
+    page_001 (表紙) と page_002 (verify) は残る。"""
     cap = _capturer_writing_seq([b"same", b"same", b"same", b"same", b"changed"])
     detect_direction(**_detect_kwargs(tmp_path, capturer=cap))
-    assert not (tmp_path / "page_001.png").exists()
-    assert not (tmp_path / "page_002.png").exists()
-    assert not (tmp_path / "page_003.png").exists()
-    assert not (tmp_path / "_origin.png").exists()
-    assert not (tmp_path / "_verify.png").exists()
+    assert (tmp_path / "page_001.png").exists()  # 表紙は残す
+    assert (tmp_path / "page_002.png").exists()  # verify は残す
+    assert not (tmp_path / "page_003.png").exists()  # 無反応 probe は削除
+    assert not (tmp_path / "page_004.png").exists()
 
 
 def test_detect_direction_raises_preflight_error_when_both_directions_unresponsive(
@@ -300,3 +290,61 @@ def test_detect_direction_error_path_leaves_no_files(tmp_path: Path) -> None:
     with pytest.raises(PreflightError):
         detect_direction(**_detect_kwargs(tmp_path, capturer=cap))
     assert list(tmp_path.glob("*.png")) == []
+
+
+# ---------------------------------------------------------------------------
+# 振る舞いベース: cover が page_001.png として最終出力に残ること (issue #59)
+# ---------------------------------------------------------------------------
+
+
+def test_detect_direction_keeps_cover_as_page_001_on_success(tmp_path: Path) -> None:
+    """成功経路: 起点フレーム（表紙）が page_001.png として保持される"""
+    cap = _capturer_writing_seq([b"COVER", b"p1", b"p2", b"p3"])
+    detect_direction(**_detect_kwargs(tmp_path, capturer=cap))
+    assert (tmp_path / "page_001.png").exists()
+    assert (tmp_path / "page_001.png").read_bytes() == b"COVER"
+
+
+def test_detect_direction_keeps_cover_as_page_001_on_fallback(tmp_path: Path) -> None:
+    """fallback 経路（probe 無反応 → 逆方向で verify）でも page_001.png は表紙のまま残る"""
+    cap = _capturer_writing_seq([b"COVER", b"COVER", b"COVER", b"COVER", b"NEXT"])
+    detect_direction(**_detect_kwargs(tmp_path, capturer=cap))
+    assert (tmp_path / "page_001.png").exists()
+    assert (tmp_path / "page_001.png").read_bytes() == b"COVER"
+
+
+def test_detect_direction_returns_cover_first_in_pngs_on_success(tmp_path: Path) -> None:
+    """成功経路: 戻り値の最初の要素は表紙 (page_001.png)、後続が probe"""
+    cap = _capturer_writing_seq([b"COVER", b"p1", b"p2", b"p3"])
+    _, pngs = detect_direction(**_detect_kwargs(tmp_path, capturer=cap))
+    assert pngs[0] == tmp_path / "page_001.png"
+    assert pngs[0].read_bytes() == b"COVER"
+
+
+def test_detect_direction_probe_pngs_start_at_page_002(tmp_path: Path) -> None:
+    """成功経路: probe で撮ったフレームは page_002..page_004"""
+    cap = _capturer_writing_seq([b"COVER", b"p1", b"p2", b"p3"])
+    _, pngs = detect_direction(**_detect_kwargs(tmp_path, capturer=cap))
+    assert [p.name for p in pngs] == [
+        "page_001.png",
+        "page_002.png",
+        "page_003.png",
+        "page_004.png",
+    ]
+
+
+def test_detect_direction_fallback_returns_cover_and_verify(tmp_path: Path) -> None:
+    """fallback 経路: 戻り値は [cover (page_001), verify (page_002)] の 2 枚"""
+    cap = _capturer_writing_seq([b"COVER", b"COVER", b"COVER", b"COVER", b"NEXT"])
+    _, pngs = detect_direction(**_detect_kwargs(tmp_path, capturer=cap))
+    assert [p.name for p in pngs] == ["page_001.png", "page_002.png"]
+    assert pngs[0].read_bytes() == b"COVER"
+    assert pngs[1].read_bytes() == b"NEXT"
+
+
+def test_detect_direction_error_removes_cover_too(tmp_path: Path) -> None:
+    """エラー経路（両方向無反応）では cover (page_001.png) も削除される"""
+    cap = _capturer_writing_seq([b"x", b"x", b"x", b"x", b"x"])
+    with pytest.raises(PreflightError):
+        detect_direction(**_detect_kwargs(tmp_path, capturer=cap))
+    assert not (tmp_path / "page_001.png").exists()


### PR DESCRIPTION
## Summary

- `--auto-direction` 時に表紙ページが出力 PNG / PDF から欠落していた不具合を修正
- `detect_direction()` が起点フレームを `_origin.png` に撮ったあと finally で削除し、probe 後のフレームを `page_001..003.png` として保存していたため
- 起点フレームを `page_001.png` として保持し、probe を `page_002..004.png` に変更
- fallback 経路 (probe 無反応 → 逆方向 verify) でも `page_001.png` (表紙) と `page_002.png` (verify) を保持
- 振る舞いベースのテスト (cover が page_001 のハッシュと一致、PDF 入力の先頭が表紙であること) を追加。既存の実装詳細 assert (`_origin.png が削除される` 等) は置換した
- README / CHANGELOG / docs/superpowers/specs を同期更新

## Test plan

- [x] `uv run pytest` (361 passed, 16 skipped)
- [x] `uv run ruff check src/ tests/` (All checks passed)
- [x] `uv run mypy src/` (no issues)
- [ ] CI green (gh pr checks)

closes #59