### PR TITLE
feat(kindle-cap): subprocess 観測性の全面整備（logging 導入 + stderr 露出）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ## [Unreleased]
 
+### Added
+
+- `kindle-cap` / `kindle-cap-pdf` に `--verbose` (`-v`) / `--quiet` (`-q`) / `--log-file PATH` CLI オプション。それぞれ DEBUG レベル有効化 / WARNING 以上のみ出力 / ログをファイルにも記録（issue #62）
+- `logging` モジュール導入（`kindle_cap` パッケージ全体）。フォーマット: `%(asctime)s %(levelname)-7s %(name)s: %(message)s`。`StreamHandler` (stderr) + optional `FileHandler` でレベル別に出力（issue #62）
+- 新規 custom exception 3 種: `kindle_cap.window.WindowGeometryError` / `kindle_cap.window.KindleActivationError` / `kindle_cap.keys.KeystrokeError`。いずれも `RuntimeError` サブクラス。subprocess osascript の失敗時、`subprocess.CalledProcessError` を捕捉して stderr 込みの具体的メッセージで raise する（issue #62）
+
+### Changed
+
+- `kindle_cap.window.activate_kindle` / `kindle_cap.keys.send_next_page` で `capture_output=True` を有効化し、`subprocess.CalledProcessError` 発生時に stderr を例外メッセージ + `logger.error` に含めるようにした。従来は stderr が握り潰されており、`exit 1` しか Traceback に残らなかった（issue #62）
+- `kindle_cap.window.get_window_geometry`: `subprocess.CalledProcessError` 発生時に `WindowGeometryError` (stderr 込み) で raise するように変更。`_parse_geometry_output` が投げていた `RuntimeError` も `WindowGeometryError` に統一（issue #62）
+- `kindle_cap.preflight._run_oscript`: 失敗時に stderr を `logger.debug` に残してから例外を再送出（`_can_send_keystrokes` の stderr 判定経路は維持、issue #62）
+- `kindle_cap.orchestrator._capture_book` のループ内で撮影 step が失敗したとき、`logger.exception` で `page N/M` + `captured so far: K` + `out_dir` を context として記録してから例外を再送出するように変更。2000 ページ撮影のような長時間ジョブで途中失敗したときの原因特定が容易になる（issue #62）
+- `kindle-cap` / `kindle-cap-pdf` の進捗 / 完了メッセージを `print()` から `logger.info` 経由に移行。`--quiet` で抑制可能。エラー表示も `typer.echo("[エラー] ...", err=True)` から `logger.error` に統一（issue #62）
+
 ## [0.2.1] - 2026-05-22
 
 ### Fixed

--- a/src/kindle_cap/capture.py
+++ b/src/kindle_cap/capture.py
@@ -1,11 +1,14 @@
 """Capture a screen rectangle using macOS screencapture."""
 
+import logging
 import subprocess
 from pathlib import Path
 
 from PIL import Image
 
 from .config import Geometry
+
+logger = logging.getLogger(__name__)
 
 
 class CaptureError(RuntimeError):
@@ -30,15 +33,22 @@ def _flatten_alpha(path: Path) -> None:
 
 
 def capture_rect(geom: Geometry, out_path: Path) -> None:
+    args = _build_screencapture_args(geom, out_path)
+    logger.debug("screencapture: %s", " ".join(args))
     # macOS の screencapture は書き込み失敗時でも exit 0 で抜けることがあるため、
     # check=True に頼らず out_path の存在を確認する。stderr は診断のため捕捉する。
     result = subprocess.run(
-        _build_screencapture_args(geom, out_path),
+        args,
         check=True,
         capture_output=True,
         text=True,
     )
     if not out_path.exists():
         stderr_text = (result.stderr or "").strip() or "(no stderr)"
+        logger.error(
+            "screencapture succeeded but file missing: %s (stderr: %s)",
+            out_path,
+            stderr_text,
+        )
         raise CaptureError(f"screencapture exited 0 but did not create {out_path}: {stderr_text}")
     _flatten_alpha(out_path)

--- a/src/kindle_cap/cli.py
+++ b/src/kindle_cap/cli.py
@@ -1,6 +1,8 @@
 """Typer-based CLI entry points for kindle_cap."""
 
+import logging
 import re
+import sys
 from pathlib import Path
 
 import typer
@@ -14,11 +16,41 @@ from .preflight import PreflightError
 # 書籍が 1000 ページを超えると 3 桁と 4 桁が混在し、辞書順 sort では
 # `page_1000.png` が `page_101.png` より先に来てしまうため数値で比較する。
 _PAGE_NUM_RE = re.compile(r"page_(\d+)\.png$")
+_LOG_FORMAT = "%(asctime)s %(levelname)-7s %(name)s: %(message)s"
 
 
 def _page_num(p: Path) -> int:
     m = _PAGE_NUM_RE.match(p.name)
     return int(m.group(1)) if m else 0
+
+
+def _setup_logging(*, verbose: bool, quiet: bool, log_file: Path | None) -> None:
+    """`kindle_cap` ロガーに StreamHandler (stderr) と optional FileHandler を attach。
+
+    `logging.basicConfig` は root logger を触るため避け、`kindle_cap` 名前空間
+    のみ操作する。既存ハンドラはクリアしてから設定 (同一プロセス内での再呼出に対応)。"""
+    if verbose and quiet:
+        raise typer.BadParameter(
+            "--verbose と --quiet は同時指定できません",
+            param_hint="--verbose / --quiet",
+        )
+    level = logging.DEBUG if verbose else (logging.WARNING if quiet else logging.INFO)
+
+    logger = logging.getLogger("kindle_cap")
+    logger.setLevel(level)
+    for handler in logger.handlers[:]:
+        handler.close()
+        logger.removeHandler(handler)
+
+    formatter = logging.Formatter(_LOG_FORMAT)
+    stream_handler = logging.StreamHandler(sys.stderr)
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+
+    if log_file is not None:
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
 
 
 def capture(
@@ -73,7 +105,25 @@ def capture(
             "表示 (1000+ ページ書籍向け、issue #53)"
         ),
     ),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        "-v",
+        help="DEBUG レベルログを有効化（osascript の cmd/stdout/stderr が見える）",
+    ),
+    quiet: bool = typer.Option(
+        False,
+        "--quiet",
+        "-q",
+        help="WARNING 以上のみ出力（進捗ログを抑制）",
+    ),
+    log_file: Path | None = typer.Option(
+        None,
+        "--log-file",
+        help="指定時はログをファイルにも記録（長時間ジョブの保険）",
+    ),
 ) -> None:
+    _setup_logging(verbose=verbose, quiet=quiet, log_file=log_file)
     if direction is not None and auto_direction:
         raise typer.BadParameter(
             "--direction と --auto-direction は同時指定できません",
@@ -141,7 +191,25 @@ def rebuild_pdf(
             "表示 (1000+ ページ書籍向け、issue #53)"
         ),
     ),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        "-v",
+        help="DEBUG レベルログを有効化",
+    ),
+    quiet: bool = typer.Option(
+        False,
+        "--quiet",
+        "-q",
+        help="WARNING 以上のみ出力",
+    ),
+    log_file: Path | None = typer.Option(
+        None,
+        "--log-file",
+        help="指定時はログをファイルにも記録",
+    ),
 ) -> None:
+    _setup_logging(verbose=verbose, quiet=quiet, log_file=log_file)
     pngs = sorted(directory.glob("page_*.png"), key=_page_num)
     if not pngs:
         typer.echo(f"[エラー] {directory} に page_*.png が見つかりません", err=True)

--- a/src/kindle_cap/cli.py
+++ b/src/kindle_cap/cli.py
@@ -8,9 +8,13 @@ from pathlib import Path
 import typer
 
 from .config import CaptureConfig, Direction
+from .keys import KeystrokeError
 from .orchestrator import run as orchestrator_run
 from .pdf import PdfBuildError, build_pdf
 from .preflight import PreflightError
+from .window import KindleActivationError, WindowGeometryError
+
+logger = logging.getLogger(__name__)
 
 # `page_{n:03d}.png` で生成された PNG を **数値順** に並べるためのキー。
 # 書籍が 1000 ページを超えると 3 桁と 4 桁が混在し、辞書順 sort では
@@ -159,11 +163,14 @@ def capture(
             auto_stop=auto_stop,
             auto_direction=auto_direction,
         )
-    except PreflightError as e:
-        typer.echo(f"[エラー] {e}", err=True)
-        raise typer.Exit(code=1) from e
-    except PdfBuildError as e:
-        typer.echo(f"[エラー] {e}", err=True)
+    except (
+        PreflightError,
+        PdfBuildError,
+        WindowGeometryError,
+        KindleActivationError,
+        KeystrokeError,
+    ) as e:
+        logger.error("%s", e)
         raise typer.Exit(code=1) from e
 
 
@@ -217,13 +224,10 @@ def rebuild_pdf(
     out_path = directory.parent / f"{directory.name}.pdf"
     try:
         build_pdf(pngs, out_path, jpeg_quality=pdf_jpeg_quality, progress=progress)
-    except PdfBuildError as e:
-        typer.echo(f"[エラー] {e}", err=True)
+    except (PdfBuildError, ValueError) as e:
+        logger.error("%s", e)
         raise typer.Exit(code=1) from e
-    except ValueError as e:
-        typer.echo(f"[エラー] {e}", err=True)
-        raise typer.Exit(code=1) from e
-    typer.echo(f"PDF を作成しました: {out_path}")
+    logger.info("PDF を作成しました: %s", out_path)
 
 
 def run_capture() -> None:

--- a/src/kindle_cap/keys.py
+++ b/src/kindle_cap/keys.py
@@ -1,11 +1,18 @@
 """Send arrow-key presses to the Kindle process via System Events."""
 
+import logging
 import subprocess
 
 from .config import Direction
 
+logger = logging.getLogger(__name__)
+
 _KEY_RIGHT = 124
 _KEY_LEFT = 123
+
+
+class KeystrokeError(RuntimeError):
+    """`send_next_page` 失敗（osascript exit 非 0）。"""
 
 
 def _key_code_for(direction: Direction) -> int:
@@ -19,8 +26,19 @@ def _build_keystroke_script(key_code: int) -> str:
 
 
 def send_next_page(direction: Direction) -> None:
-    script = _build_keystroke_script(_key_code_for(direction))
-    subprocess.run(
-        ["osascript", "-e", script],
-        check=True,
-    )
+    key_code = _key_code_for(direction)
+    script = _build_keystroke_script(key_code)
+    logger.debug("sending key code %d (direction=%s)", key_code, direction.value)
+    try:
+        subprocess.run(
+            ["osascript", "-e", script],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        stderr_text = (e.stderr or "").strip() or "(no stderr)"
+        logger.error("keystroke osascript failed (exit %d): %s", e.returncode, stderr_text)
+        raise KeystrokeError(
+            f"osascript keystroke failed (exit {e.returncode}): {stderr_text}"
+        ) from e

--- a/src/kindle_cap/orchestrator.py
+++ b/src/kindle_cap/orchestrator.py
@@ -3,6 +3,7 @@
 import contextlib
 import dataclasses
 import hashlib
+import logging
 from pathlib import Path
 from time import sleep
 
@@ -12,6 +13,8 @@ from .keys import send_next_page
 from .pdf import build_pdf
 from .preflight import detect_direction, preflight
 from .window import activate_kindle, get_window_geometry
+
+logger = logging.getLogger(__name__)
 
 
 def run(
@@ -96,20 +99,27 @@ def _capture_book(
                 send_next_page(config.direction)
                 sleep(config.wait)
 
-            print(f"[{i}/{config.pages}] capturing page", flush=True)
-            activate_kindle()
-            geom = get_window_geometry()
-            png_path = out_dir / f"page_{i:03d}.png"
-            capture_rect(geom, png_path)
+            logger.info("[%d/%d] capturing page", i, config.pages)
+            try:
+                activate_kindle()
+                geom = get_window_geometry()
+                png_path = out_dir / f"page_{i:03d}.png"
+                capture_rect(geom, png_path)
+            except Exception:
+                logger.exception(
+                    "page %d/%d capture failed (captured so far: %d, out_dir=%s)",
+                    i,
+                    config.pages,
+                    len(captured),
+                    out_dir,
+                )
+                raise
 
             if auto_stop:
                 current_hash = _image_hash(png_path)
                 if current_hash == last_hash:
                     png_path.unlink(missing_ok=True)
-                    print(
-                        f"終端を検出（前ページと同一）。{len(captured)} ページで停止",
-                        flush=True,
-                    )
+                    logger.info("終端を検出（前ページと同一）。%d ページで停止", len(captured))
                     break
                 last_hash = current_hash
 
@@ -118,14 +128,15 @@ def _capture_book(
                 send_next_page(config.direction)
                 sleep(config.wait)
     except KeyboardInterrupt:
-        print(
-            f"\n中断しました。{len(captured)}/{config.pages} ページまで撮影済み。"
-            " PNG は保持し、PDF は作成しません。"
+        logger.warning(
+            "中断しました。%d/%d ページまで撮影済み。PNG は保持し、PDF は作成しません。",
+            len(captured),
+            config.pages,
         )
         return
 
     if not captured:
-        print(f"撮影 0 ページ。{config.name} の PDF はスキップ", flush=True)
+        logger.warning("撮影 0 ページ。%s の PDF はスキップ", config.name)
         return
 
     pdf_path = config.out / f"{config.name}.pdf"
@@ -142,7 +153,7 @@ def _capture_book(
         with contextlib.suppress(OSError):
             out_dir.rmdir()
 
-    print(f"完了: {pdf_path}")
+    logger.info("完了: %s", pdf_path)
 
 
 def _run_dry(config: CaptureConfig) -> None:
@@ -150,8 +161,8 @@ def _run_dry(config: CaptureConfig) -> None:
     geom = get_window_geometry()
     dry_path = config.out / "dry_run.png"
     capture_rect(geom, dry_path)
-    print(f"window geometry: x={geom.x} y={geom.y} w={geom.width} h={geom.height}")
-    print(f"saved: {dry_path}")
+    logger.info("window geometry: x=%d y=%d w=%d h=%d", geom.x, geom.y, geom.width, geom.height)
+    logger.info("saved: %s", dry_path)
 
 
 def _purge_old_pages(out_dir: Path) -> None:

--- a/src/kindle_cap/preflight.py
+++ b/src/kindle_cap/preflight.py
@@ -1,11 +1,14 @@
 """Validate prerequisites before starting the capture loop."""
 
 import hashlib
+import logging
 import subprocess
 from collections.abc import Callable
 from pathlib import Path
 
 from .config import Direction, Geometry
+
+logger = logging.getLogger(__name__)
 
 
 class PreflightError(RuntimeError):
@@ -32,12 +35,20 @@ def _is_accessibility_error(stderr: str | None) -> bool:
 
 
 def _run_oscript(script: str) -> str:
-    result = subprocess.run(
-        ["osascript", "-e", script],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    logger.debug("preflight osascript: %s", script)
+    try:
+        result = subprocess.run(
+            ["osascript", "-e", script],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        stderr_text = (e.stderr or "").strip() or "(no stderr)"
+        # 呼び出し側 _can_send_keystrokes で stderr 判定するため raise 自体は素通し。
+        # ただし debug ログには必ず stderr を残す。
+        logger.debug("preflight osascript failed (exit %d): %s", e.returncode, stderr_text)
+        raise
     return result.stdout
 
 
@@ -60,6 +71,7 @@ def _can_send_keystrokes() -> bool:
 
 
 def preflight() -> None:
+    logger.debug("running preflight checks")
     if not _is_kindle_running():
         raise PreflightError("Kindle.app を起動してください（プロセスが見つかりません）")
     if not _has_kindle_window():
@@ -70,6 +82,7 @@ def preflight() -> None:
             "システム設定 > プライバシーとセキュリティ > アクセシビリティ で\n"
             "ターミナル（iTerm2 等）に許可を与えてください。"
         )
+    logger.debug("preflight checks passed")
 
 
 def _md5(path: Path) -> str:
@@ -104,6 +117,11 @@ def detect_direction(
     先頭が表紙 (page_001.png)、後続が probe direction で進めた後のフレーム。
     呼び出し側 _capture_book に start_index = len(...) + 1 / seed_hashes として渡す。
     """
+    logger.debug(
+        "detect_direction start (probe_direction=%s, probe_count=%d)",
+        probe_direction.value,
+        probe_count,
+    )
     activator()
     geom = geom_provider()
     cover_path = out_dir / "page_001.png"
@@ -123,9 +141,11 @@ def detect_direction(
 
         if _md5(probe_pngs[-1]) != cover_hash:
             keep_cover = True
+            logger.debug("detect_direction resolved: %s", probe_direction.value)
             return probe_direction, [cover_path, *probe_pngs]
 
         # probe 無反応 → 試写を全削除して逆方向で確認
+        logger.debug("probe direction %s unresponsive, trying fallback", probe_direction.value)
         for p in probe_pngs:
             p.unlink(missing_ok=True)
         other = Direction.LTR if probe_direction is Direction.RTL else Direction.RTL
@@ -137,6 +157,7 @@ def detect_direction(
         capturer(geom, verify_path)
         if _md5(verify_path) != cover_hash:
             keep_cover = True
+            logger.debug("detect_direction resolved (fallback): %s", other.value)
             return other, [cover_path, verify_path]
         verify_path.unlink(missing_ok=True)
 

--- a/src/kindle_cap/window.py
+++ b/src/kindle_cap/window.py
@@ -1,8 +1,11 @@
 """Activate the Kindle app and read its window geometry via AppleScript."""
 
+import logging
 import subprocess
 
 from .config import Geometry
+
+logger = logging.getLogger(__name__)
 
 _ACTIVATE_SCRIPT = 'tell application "Amazon Kindle" to activate'
 
@@ -14,31 +17,62 @@ _GEOMETRY_SCRIPT = """tell application "System Events" to tell process "Kindle"
 end tell"""
 
 
+class WindowGeometryError(RuntimeError):
+    """`get_window_geometry` 失敗（osascript exit 非 0 / stdout 解析失敗）。"""
+
+
+class KindleActivationError(RuntimeError):
+    """`activate_kindle` 失敗（osascript exit 非 0）。"""
+
+
 def _parse_geometry_output(stdout: str) -> Geometry:
     if stdout.strip() == "":
-        raise RuntimeError(f"unexpected geometry output: {stdout!r}")
+        raise WindowGeometryError(f"unexpected geometry output: {stdout!r}")
     parts = stdout.strip().split("\n")
     if len(parts) != 4:
-        raise RuntimeError(f"unexpected geometry output: {stdout!r}")
+        raise WindowGeometryError(f"unexpected geometry output: {stdout!r}")
     try:
         x, y, w, h = (int(p.strip()) for p in parts)
     except ValueError as e:
-        raise RuntimeError(f"could not parse geometry output: {stdout!r}") from e
+        raise WindowGeometryError(f"could not parse geometry output: {stdout!r}") from e
     return Geometry(x=x, y=y, width=w, height=h)
 
 
+def _stderr_text(stderr: str | None) -> str:
+    return (stderr or "").strip() or "(no stderr)"
+
+
 def activate_kindle() -> None:
-    subprocess.run(
-        ["osascript", "-e", _ACTIVATE_SCRIPT],
-        check=True,
-    )
+    logger.debug("activating Amazon Kindle via osascript")
+    try:
+        subprocess.run(
+            ["osascript", "-e", _ACTIVATE_SCRIPT],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        text = _stderr_text(e.stderr)
+        logger.error("Kindle activation failed (exit %d): %s", e.returncode, text)
+        raise KindleActivationError(
+            f"osascript activate failed (exit {e.returncode}): {text}"
+        ) from e
 
 
 def get_window_geometry() -> Geometry:
-    result = subprocess.run(
-        ["osascript", "-e", _GEOMETRY_SCRIPT],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    logger.debug("running osascript geometry probe")
+    try:
+        result = subprocess.run(
+            ["osascript", "-e", _GEOMETRY_SCRIPT],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        text = _stderr_text(e.stderr)
+        logger.error("geometry osascript failed (exit %d): %s", e.returncode, text)
+        raise WindowGeometryError(
+            f"osascript geometry probe failed (exit {e.returncode}): {text}"
+        ) from e
+    logger.debug("geometry stdout: %r", result.stdout)
     return _parse_geometry_output(result.stdout)

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -1,3 +1,4 @@
+import logging
 import subprocess
 from collections.abc import Callable
 from pathlib import Path
@@ -238,3 +239,39 @@ def test_capture_rect_error_includes_out_path(
     mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
     with pytest.raises(CaptureError, match=r"page_153\.png"):
         capture_rect(Geometry(0, 0, 10, 10), out)
+
+
+# ---------------------------------------------------------------------------
+# capture_rect のロギング (issue #62)
+# ---------------------------------------------------------------------------
+
+
+@patch("kindle_cap.capture.subprocess.run")
+def test_capture_rect_logs_screencapture_command(
+    mock_run: MagicMock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    out = tmp_path / "p.png"
+    mock_run.side_effect = _stub_screencapture_factory(out)
+    caplog.set_level(logging.DEBUG, logger="kindle_cap")
+    capture_rect(Geometry(10, 20, 30, 40), out)
+    assert "screencapture" in caplog.text
+    assert "10,20,30,40" in caplog.text
+
+
+@patch("kindle_cap.capture.subprocess.run")
+def test_capture_rect_logs_error_when_file_missing(
+    mock_run: MagicMock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    out = tmp_path / "missing.png"
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="", stderr="screencapture: cannot write file"
+    )
+    caplog.set_level(logging.ERROR, logger="kindle_cap")
+    with pytest.raises(CaptureError):
+        capture_rect(Geometry(0, 0, 10, 10), out)
+    assert "screencapture succeeded but file missing" in caplog.text
+    assert "cannot write file" in caplog.text

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -9,7 +9,9 @@ from typer.testing import CliRunner
 
 from kindle_cap.cli import capture, rebuild_pdf
 from kindle_cap.config import Direction
+from kindle_cap.keys import KeystrokeError
 from kindle_cap.pdf import PdfBuildError
+from kindle_cap.window import KindleActivationError, WindowGeometryError
 
 
 @pytest.fixture(autouse=True)
@@ -644,3 +646,47 @@ def test_rebuild_pdf_log_file_adds_file_handler(mock_build: MagicMock, tmp_path:
     logger = logging.getLogger("kindle_cap")
     file_handlers = [h for h in logger.handlers if isinstance(h, logging.FileHandler)]
     assert any(Path(h.baseFilename) == log_path for h in file_handlers)
+
+
+# ---------------------------------------------------------------------------
+# 新規 custom exception のハンドリング (issue #62)
+# ---------------------------------------------------------------------------
+
+
+@patch("kindle_cap.cli.orchestrator_run")
+def test_capture_window_geometry_error_exits_nonzero(mock_run: MagicMock, tmp_path: Path) -> None:
+    """WindowGeometryError は exit 1 + メッセージを stderr に出して終わる (traceback ではない)"""
+    mock_run.side_effect = WindowGeometryError(
+        "osascript geometry probe failed (exit 1): isn't running"
+    )
+    app = _make_app(capture)
+    result = runner.invoke(
+        app,
+        ["--name", "x", "--pages", "1", "--direction", "rtl", "--out", str(tmp_path)],
+    )
+    assert result.exit_code != 0
+    assert "isn't running" in result.output
+
+
+@patch("kindle_cap.cli.orchestrator_run")
+def test_capture_kindle_activation_error_exits_nonzero(mock_run: MagicMock, tmp_path: Path) -> None:
+    mock_run.side_effect = KindleActivationError("osascript activate failed (exit 1): some error")
+    app = _make_app(capture)
+    result = runner.invoke(
+        app,
+        ["--name", "x", "--pages", "1", "--direction", "rtl", "--out", str(tmp_path)],
+    )
+    assert result.exit_code != 0
+    assert "activate failed" in result.output
+
+
+@patch("kindle_cap.cli.orchestrator_run")
+def test_capture_keystroke_error_exits_nonzero(mock_run: MagicMock, tmp_path: Path) -> None:
+    mock_run.side_effect = KeystrokeError("osascript keystroke failed (exit 1): some error")
+    app = _make_app(capture)
+    result = runner.invoke(
+        app,
+        ["--name", "x", "--pages", "1", "--direction", "rtl", "--out", str(tmp_path)],
+    )
+    assert result.exit_code != 0
+    assert "keystroke failed" in result.output

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,13 +1,30 @@
-from collections.abc import Callable
+import logging
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 import typer
 from typer.testing import CliRunner
 
 from kindle_cap.cli import capture, rebuild_pdf
 from kindle_cap.config import Direction
 from kindle_cap.pdf import PdfBuildError
+
+
+@pytest.fixture(autouse=True)
+def _reset_kindle_cap_logger() -> Iterator[None]:
+    """各テスト後に `kindle_cap` ロガーをリセット（テスト間漏れ防止）。
+
+    `_setup_logging` は handler を attach するため、複数テストで呼ばれると
+    handler が累積し、FileHandler はファイルハンドルを開いたままになる。"""
+    yield
+    logger = logging.getLogger("kindle_cap")
+    for handler in logger.handlers[:]:
+        handler.close()
+        logger.removeHandler(handler)
+    logger.setLevel(logging.NOTSET)
+
 
 runner = CliRunner()
 
@@ -449,3 +466,181 @@ def test_rebuild_pdf_orders_pngs_numerically_3digit_only(
         "page_100.png",
         "page_999.png",
     ]
+
+
+# ---------------------------------------------------------------------------
+# logging 設定: --verbose / --quiet / --log-file (issue #62)
+# ---------------------------------------------------------------------------
+
+
+@patch("kindle_cap.cli.orchestrator_run")
+def test_capture_default_log_level_is_info(mock_run: MagicMock, tmp_path: Path) -> None:
+    app = _make_app(capture)
+    result = runner.invoke(
+        app,
+        ["--name", "x", "--pages", "1", "--direction", "rtl", "--out", str(tmp_path)],
+    )
+    assert result.exit_code == 0, result.output
+    assert logging.getLogger("kindle_cap").level == logging.INFO
+
+
+@patch("kindle_cap.cli.orchestrator_run")
+def test_capture_verbose_sets_debug_level(mock_run: MagicMock, tmp_path: Path) -> None:
+    app = _make_app(capture)
+    result = runner.invoke(
+        app,
+        [
+            "--name",
+            "x",
+            "--pages",
+            "1",
+            "--direction",
+            "rtl",
+            "--out",
+            str(tmp_path),
+            "--verbose",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert logging.getLogger("kindle_cap").level == logging.DEBUG
+
+
+@patch("kindle_cap.cli.orchestrator_run")
+def test_capture_verbose_short_flag(mock_run: MagicMock, tmp_path: Path) -> None:
+    app = _make_app(capture)
+    result = runner.invoke(
+        app,
+        ["--name", "x", "--pages", "1", "--direction", "rtl", "--out", str(tmp_path), "-v"],
+    )
+    assert result.exit_code == 0, result.output
+    assert logging.getLogger("kindle_cap").level == logging.DEBUG
+
+
+@patch("kindle_cap.cli.orchestrator_run")
+def test_capture_quiet_sets_warning_level(mock_run: MagicMock, tmp_path: Path) -> None:
+    app = _make_app(capture)
+    result = runner.invoke(
+        app,
+        [
+            "--name",
+            "x",
+            "--pages",
+            "1",
+            "--direction",
+            "rtl",
+            "--out",
+            str(tmp_path),
+            "--quiet",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert logging.getLogger("kindle_cap").level == logging.WARNING
+
+
+@patch("kindle_cap.cli.orchestrator_run")
+def test_capture_quiet_short_flag(mock_run: MagicMock, tmp_path: Path) -> None:
+    app = _make_app(capture)
+    result = runner.invoke(
+        app,
+        ["--name", "x", "--pages", "1", "--direction", "rtl", "--out", str(tmp_path), "-q"],
+    )
+    assert result.exit_code == 0, result.output
+    assert logging.getLogger("kindle_cap").level == logging.WARNING
+
+
+@patch("kindle_cap.cli.orchestrator_run")
+def test_capture_verbose_and_quiet_conflict_exits_nonzero(
+    mock_run: MagicMock, tmp_path: Path
+) -> None:
+    app = _make_app(capture)
+    result = runner.invoke(
+        app,
+        [
+            "--name",
+            "x",
+            "--pages",
+            "1",
+            "--direction",
+            "rtl",
+            "--out",
+            str(tmp_path),
+            "--verbose",
+            "--quiet",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "同時指定" in result.output
+
+
+@patch("kindle_cap.cli.orchestrator_run")
+def test_capture_log_file_adds_file_handler(mock_run: MagicMock, tmp_path: Path) -> None:
+    log_path = tmp_path / "kc.log"
+    app = _make_app(capture)
+    result = runner.invoke(
+        app,
+        [
+            "--name",
+            "x",
+            "--pages",
+            "1",
+            "--direction",
+            "rtl",
+            "--out",
+            str(tmp_path),
+            "--log-file",
+            str(log_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    logger = logging.getLogger("kindle_cap")
+    file_handlers = [h for h in logger.handlers if isinstance(h, logging.FileHandler)]
+    assert any(Path(h.baseFilename) == log_path for h in file_handlers)
+
+
+@patch("kindle_cap.cli.build_pdf")
+def test_rebuild_pdf_verbose_sets_debug_level(mock_build: MagicMock, tmp_path: Path) -> None:
+    book = tmp_path / "bk"
+    book.mkdir()
+    (book / "page_001.png").write_bytes(b"a")
+    app = _make_app(rebuild_pdf)
+    result = runner.invoke(app, [str(book), "--verbose"])
+    assert result.exit_code == 0, result.output
+    assert logging.getLogger("kindle_cap").level == logging.DEBUG
+
+
+@patch("kindle_cap.cli.build_pdf")
+def test_rebuild_pdf_quiet_sets_warning_level(mock_build: MagicMock, tmp_path: Path) -> None:
+    book = tmp_path / "bk"
+    book.mkdir()
+    (book / "page_001.png").write_bytes(b"a")
+    app = _make_app(rebuild_pdf)
+    result = runner.invoke(app, [str(book), "--quiet"])
+    assert result.exit_code == 0, result.output
+    assert logging.getLogger("kindle_cap").level == logging.WARNING
+
+
+@patch("kindle_cap.cli.build_pdf")
+def test_rebuild_pdf_verbose_and_quiet_conflict_exits_nonzero(
+    mock_build: MagicMock, tmp_path: Path
+) -> None:
+    book = tmp_path / "bk"
+    book.mkdir()
+    (book / "page_001.png").write_bytes(b"a")
+    app = _make_app(rebuild_pdf)
+    result = runner.invoke(app, [str(book), "--verbose", "--quiet"])
+    assert result.exit_code != 0
+    assert "同時指定" in result.output
+
+
+@patch("kindle_cap.cli.build_pdf")
+def test_rebuild_pdf_log_file_adds_file_handler(mock_build: MagicMock, tmp_path: Path) -> None:
+    log_path = tmp_path / "kc.log"
+    book = tmp_path / "bk"
+    book.mkdir()
+    (book / "page_001.png").write_bytes(b"a")
+    app = _make_app(rebuild_pdf)
+    result = runner.invoke(app, [str(book), "--log-file", str(log_path)])
+    assert result.exit_code == 0, result.output
+    logger = logging.getLogger("kindle_cap")
+    file_handlers = [h for h in logger.handlers if isinstance(h, logging.FileHandler)]
+    assert any(Path(h.baseFilename) == log_path for h in file_handlers)

--- a/tests/unit/test_keys.py
+++ b/tests/unit/test_keys.py
@@ -1,9 +1,12 @@
+import logging
+import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from kindle_cap.config import Direction
 from kindle_cap.keys import (
+    KeystrokeError,
     _build_keystroke_script,
     _key_code_for,
     send_next_page,
@@ -85,3 +88,76 @@ def test_send_next_page_ltr_passes_left_arrow_script(mock_run: MagicMock) -> Non
 def test_send_next_page_uses_check_true(mock_run: MagicMock) -> None:
     send_next_page(Direction.RTL)
     assert mock_run.call_args.kwargs.get("check") is True
+
+
+# ---------------------------------------------------------------------------
+# CalledProcessError → custom exception ラップ + logger (issue #62)
+# ---------------------------------------------------------------------------
+
+
+def _make_called_process_error(
+    stderr: str | None, returncode: int = 1
+) -> subprocess.CalledProcessError:
+    return subprocess.CalledProcessError(
+        returncode=returncode,
+        cmd=["osascript", "-e", "..."],
+        output="",
+        stderr=stderr,
+    )
+
+
+def test_keystroke_error_is_runtime_error_subclass() -> None:
+    assert issubclass(KeystrokeError, RuntimeError)
+
+
+@patch("kindle_cap.keys.subprocess.run")
+def test_send_next_page_captures_output(mock_run: MagicMock) -> None:
+    """既存挙動からの変更点として、capture_output=True が指定される。"""
+    send_next_page(Direction.RTL)
+    assert mock_run.call_args.kwargs.get("capture_output") is True
+    assert mock_run.call_args.kwargs.get("text") is True
+
+
+@patch("kindle_cap.keys.subprocess.run")
+def test_send_next_page_wraps_called_process_error_with_stderr(
+    mock_run: MagicMock,
+) -> None:
+    mock_run.side_effect = _make_called_process_error(
+        "execution error: process Kindle isn't running (-1719)"
+    )
+    with pytest.raises(KeystrokeError, match="isn't running"):
+        send_next_page(Direction.RTL)
+
+
+@patch("kindle_cap.keys.subprocess.run")
+def test_send_next_page_includes_exit_code_in_message(mock_run: MagicMock) -> None:
+    mock_run.side_effect = _make_called_process_error("err", returncode=2)
+    with pytest.raises(KeystrokeError, match="exit 2"):
+        send_next_page(Direction.RTL)
+
+
+@patch("kindle_cap.keys.subprocess.run")
+def test_send_next_page_handles_empty_stderr(mock_run: MagicMock) -> None:
+    mock_run.side_effect = _make_called_process_error("")
+    with pytest.raises(KeystrokeError, match="no stderr"):
+        send_next_page(Direction.RTL)
+
+
+@patch("kindle_cap.keys.subprocess.run")
+def test_send_next_page_handles_none_stderr(mock_run: MagicMock) -> None:
+    mock_run.side_effect = _make_called_process_error(None)
+    with pytest.raises(KeystrokeError, match="no stderr"):
+        send_next_page(Direction.RTL)
+
+
+@patch("kindle_cap.keys.subprocess.run")
+def test_send_next_page_logs_error_on_failure(
+    mock_run: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mock_run.side_effect = _make_called_process_error("keystroke oops")
+    caplog.set_level(logging.ERROR, logger="kindle_cap")
+    with pytest.raises(KeystrokeError):
+        send_next_page(Direction.RTL)
+    assert "keystroke osascript failed" in caplog.text
+    assert "keystroke oops" in caplog.text

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -7,6 +8,7 @@ import pytest
 from kindle_cap.config import CaptureConfig, Direction, Geometry
 from kindle_cap.orchestrator import _capture_book, _image_hash, run
 from kindle_cap.preflight import PreflightError
+from kindle_cap.window import WindowGeometryError
 
 _GEOM = Geometry(x=0, y=0, width=100, height=100)
 
@@ -199,15 +201,15 @@ def test_run_prints_progress_for_each_page(
     mock_send: MagicMock,
     mock_pdf: MagicMock,
     tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """長尺キャプチャの UX として、各ページごとに進捗を出すこと"""
+    """長尺キャプチャの UX として、各ページごとに進捗ログを出すこと"""
     mock_geom.return_value = _GEOM
+    caplog.set_level(logging.INFO, logger="kindle_cap")
     run(_config(tmp_path, pages=3))
-    out = capsys.readouterr().out
-    assert "1/3" in out
-    assert "2/3" in out
-    assert "3/3" in out
+    assert "1/3" in caplog.text
+    assert "2/3" in caplog.text
+    assert "3/3" in caplog.text
 
 
 @patch("kindle_cap.orchestrator.build_pdf")
@@ -224,13 +226,13 @@ def test_run_progress_reflects_actual_page_count(
     mock_send: MagicMock,
     mock_pdf: MagicMock,
     tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """N ページ指定なら 'N/N' まで含まれること（最終ページの進捗が抜けないこと）"""
     mock_geom.return_value = _GEOM
+    caplog.set_level(logging.INFO, logger="kindle_cap")
     run(_config(tmp_path, pages=10))
-    out = capsys.readouterr().out
-    assert "10/10" in out
+    assert "10/10" in caplog.text
 
 
 @patch("kindle_cap.orchestrator.build_pdf")
@@ -247,13 +249,13 @@ def test_run_dry_run_does_not_print_progress_count(
     mock_send: MagicMock,
     mock_pdf: MagicMock,
     tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """dry-run はループしないので 1/N 形式の進捗は出ない"""
     mock_geom.return_value = _GEOM
+    caplog.set_level(logging.INFO, logger="kindle_cap")
     run(_config(tmp_path, pages=1), dry_run=True)
-    out = capsys.readouterr().out
-    assert "1/1" not in out
+    assert "1/1" not in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -765,3 +767,85 @@ def test_run_dry_run_with_auto_direction_skips_detect(
     run(config, dry_run=True, auto_direction=True)
     assert not mock_detect.called
     assert mock_cap.call_count == 1  # _run_dry の 1 枚撮影のみ
+
+
+# ---------------------------------------------------------------------------
+# _capture_book ループ内の例外時 context ロギング (issue #62)
+# ---------------------------------------------------------------------------
+
+
+@patch("kindle_cap.orchestrator.build_pdf")
+@patch("kindle_cap.orchestrator.send_next_page")
+@patch("kindle_cap.orchestrator.capture_rect")
+@patch("kindle_cap.orchestrator.get_window_geometry")
+@patch("kindle_cap.orchestrator.activate_kindle")
+@patch("kindle_cap.orchestrator.preflight")
+def test_run_logs_page_context_on_geometry_failure(
+    mock_pre: MagicMock,
+    mock_act: MagicMock,
+    mock_geom: MagicMock,
+    mock_cap: MagicMock,
+    mock_send: MagicMock,
+    mock_pdf: MagicMock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """get_window_geometry が 3 ページ目で失敗したとき、page 3/5 + 撮影済み 2 ページが log に残る"""
+    mock_geom.side_effect = [
+        _GEOM,
+        _GEOM,
+        WindowGeometryError("osascript geometry probe failed (exit 1): isn't running"),
+    ]
+    caplog.set_level(logging.ERROR, logger="kindle_cap")
+    with pytest.raises(WindowGeometryError):
+        run(_config(tmp_path, pages=5))
+    assert "page 3/5" in caplog.text
+    assert "captured so far: 2" in caplog.text
+
+
+@patch("kindle_cap.orchestrator.build_pdf")
+@patch("kindle_cap.orchestrator.send_next_page")
+@patch("kindle_cap.orchestrator.capture_rect")
+@patch("kindle_cap.orchestrator.get_window_geometry")
+@patch("kindle_cap.orchestrator.activate_kindle")
+@patch("kindle_cap.orchestrator.preflight")
+def test_run_propagates_geometry_error_after_logging(
+    mock_pre: MagicMock,
+    mock_act: MagicMock,
+    mock_geom: MagicMock,
+    mock_cap: MagicMock,
+    mock_send: MagicMock,
+    mock_pdf: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """ループ内例外は logger に context 出してから raise される (PDF は作らない)"""
+    mock_geom.side_effect = [_GEOM, WindowGeometryError("boom")]
+    with pytest.raises(WindowGeometryError, match="boom"):
+        run(_config(tmp_path, pages=5))
+    mock_pdf.assert_not_called()
+
+
+@patch("kindle_cap.orchestrator.build_pdf")
+@patch("kindle_cap.orchestrator.send_next_page")
+@patch("kindle_cap.orchestrator.capture_rect")
+@patch("kindle_cap.orchestrator.get_window_geometry")
+@patch("kindle_cap.orchestrator.activate_kindle")
+@patch("kindle_cap.orchestrator.preflight")
+def test_run_keyboard_interrupt_path_does_not_trigger_failure_log(
+    mock_pre: MagicMock,
+    mock_act: MagicMock,
+    mock_geom: MagicMock,
+    mock_cap: MagicMock,
+    mock_send: MagicMock,
+    mock_pdf: MagicMock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """KeyboardInterrupt は既存のループ外 except でハンドリングされ、
+    page capture failed の error ログは出ない (Ctrl-C は失敗ではない)"""
+    mock_geom.return_value = _GEOM
+    mock_cap.side_effect = [None, KeyboardInterrupt(), None]
+    caplog.set_level(logging.ERROR, logger="kindle_cap")
+    run(_config(tmp_path, pages=5))
+    assert "capture failed" not in caplog.text
+    mock_pdf.assert_not_called()

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -1,3 +1,4 @@
+import logging
 import subprocess
 from collections.abc import Callable
 from pathlib import Path
@@ -11,6 +12,7 @@ from kindle_cap.preflight import (
     PreflightError,
     _is_accessibility_error,
     _parse_count,
+    _run_oscript,
     detect_direction,
     preflight,
 )
@@ -348,3 +350,51 @@ def test_detect_direction_error_removes_cover_too(tmp_path: Path) -> None:
     with pytest.raises(PreflightError):
         detect_direction(**_detect_kwargs(tmp_path, capturer=cap))
     assert not (tmp_path / "page_001.png").exists()
+
+
+# ---------------------------------------------------------------------------
+# _run_oscript のロギング (issue #62)
+# ---------------------------------------------------------------------------
+
+
+@patch("kindle_cap.preflight.subprocess.run")
+def test_run_oscript_logs_script_on_invocation(
+    mock_run: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """_run_oscript は呼び出し時に script を debug ログに残す"""
+    mock_run.return_value = MagicMock(stdout="Finder\n")
+    caplog.set_level(logging.DEBUG, logger="kindle_cap")
+    _run_oscript('tell application "System Events" to get name of first process')
+    assert "preflight osascript" in caplog.text
+    assert "System Events" in caplog.text
+
+
+@patch("kindle_cap.preflight.subprocess.run")
+def test_run_oscript_logs_stderr_on_failure_and_reraises(
+    mock_run: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """_run_oscript は失敗時に stderr を debug ログに残してから例外を再送出する。
+    (呼び出し側 _can_send_keystrokes で stderr 判定するため raise 自体は素通し)"""
+    err = subprocess.CalledProcessError(2, "osascript", stderr="execution error: some failure")
+    mock_run.side_effect = err
+    caplog.set_level(logging.DEBUG, logger="kindle_cap")
+    with pytest.raises(subprocess.CalledProcessError):
+        _run_oscript('tell application "System Events" to count processes')
+    assert "preflight osascript failed" in caplog.text
+    assert "execution error" in caplog.text
+
+
+@patch("kindle_cap.preflight.subprocess.run")
+def test_run_oscript_handles_none_stderr_in_log(
+    mock_run: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """stderr=None でも debug ログでクラッシュしないこと"""
+    err = subprocess.CalledProcessError(1, "osascript", stderr=None)
+    mock_run.side_effect = err
+    caplog.set_level(logging.DEBUG, logger="kindle_cap")
+    with pytest.raises(subprocess.CalledProcessError):
+        _run_oscript("anything")
+    assert "preflight osascript failed" in caplog.text

--- a/tests/unit/test_window.py
+++ b/tests/unit/test_window.py
@@ -1,9 +1,13 @@
+import logging
+import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from kindle_cap.config import Geometry
 from kindle_cap.window import (
+    KindleActivationError,
+    WindowGeometryError,
     _parse_geometry_output,
     activate_kindle,
     get_window_geometry,
@@ -123,3 +127,118 @@ def test_get_window_geometry_propagates_parse_error(mock_run: MagicMock) -> None
     mock_run.return_value = MagicMock(stdout="garbage\n")
     with pytest.raises(RuntimeError):
         get_window_geometry()
+
+
+# ---------------------------------------------------------------------------
+# CalledProcessError → custom exception ラップ + logger (issue #62)
+# ---------------------------------------------------------------------------
+
+
+def _make_called_process_error(
+    stderr: str | None, returncode: int = 1
+) -> subprocess.CalledProcessError:
+    return subprocess.CalledProcessError(
+        returncode=returncode,
+        cmd=["osascript", "-e", "..."],
+        output="",
+        stderr=stderr,
+    )
+
+
+def test_window_geometry_error_is_runtime_error_subclass() -> None:
+    assert issubclass(WindowGeometryError, RuntimeError)
+
+
+def test_kindle_activation_error_is_runtime_error_subclass() -> None:
+    assert issubclass(KindleActivationError, RuntimeError)
+
+
+@patch("kindle_cap.window.subprocess.run")
+def test_get_window_geometry_wraps_called_process_error_with_stderr(
+    mock_run: MagicMock,
+) -> None:
+    mock_run.side_effect = _make_called_process_error(
+        "execution error: process Kindle isn't running (-1719)"
+    )
+    with pytest.raises(WindowGeometryError, match="isn't running"):
+        get_window_geometry()
+
+
+@patch("kindle_cap.window.subprocess.run")
+def test_get_window_geometry_includes_exit_code_in_message(mock_run: MagicMock) -> None:
+    mock_run.side_effect = _make_called_process_error("some error", returncode=2)
+    with pytest.raises(WindowGeometryError, match="exit 2"):
+        get_window_geometry()
+
+
+@patch("kindle_cap.window.subprocess.run")
+def test_get_window_geometry_handles_empty_stderr(mock_run: MagicMock) -> None:
+    mock_run.side_effect = _make_called_process_error("")
+    with pytest.raises(WindowGeometryError, match="no stderr"):
+        get_window_geometry()
+
+
+@patch("kindle_cap.window.subprocess.run")
+def test_get_window_geometry_handles_none_stderr(mock_run: MagicMock) -> None:
+    mock_run.side_effect = _make_called_process_error(None)
+    with pytest.raises(WindowGeometryError, match="no stderr"):
+        get_window_geometry()
+
+
+@patch("kindle_cap.window.subprocess.run")
+def test_get_window_geometry_logs_error_on_failure(
+    mock_run: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mock_run.side_effect = _make_called_process_error("oops")
+    caplog.set_level(logging.ERROR, logger="kindle_cap")
+    with pytest.raises(WindowGeometryError):
+        get_window_geometry()
+    assert "geometry osascript failed" in caplog.text
+    assert "oops" in caplog.text
+
+
+@patch("kindle_cap.window.subprocess.run")
+def test_activate_kindle_captures_output(mock_run: MagicMock) -> None:
+    """既存挙動からの変更点として、capture_output=True が指定される。"""
+    activate_kindle()
+    assert mock_run.call_args.kwargs.get("capture_output") is True
+    assert mock_run.call_args.kwargs.get("text") is True
+
+
+@patch("kindle_cap.window.subprocess.run")
+def test_activate_kindle_wraps_called_process_error_with_stderr(
+    mock_run: MagicMock,
+) -> None:
+    mock_run.side_effect = _make_called_process_error(
+        "execution error: Application isn't running (-600)"
+    )
+    with pytest.raises(KindleActivationError, match="isn't running"):
+        activate_kindle()
+
+
+@patch("kindle_cap.window.subprocess.run")
+def test_activate_kindle_includes_exit_code_in_message(mock_run: MagicMock) -> None:
+    mock_run.side_effect = _make_called_process_error("err", returncode=3)
+    with pytest.raises(KindleActivationError, match="exit 3"):
+        activate_kindle()
+
+
+@patch("kindle_cap.window.subprocess.run")
+def test_activate_kindle_handles_empty_stderr(mock_run: MagicMock) -> None:
+    mock_run.side_effect = _make_called_process_error("")
+    with pytest.raises(KindleActivationError, match="no stderr"):
+        activate_kindle()
+
+
+@patch("kindle_cap.window.subprocess.run")
+def test_activate_kindle_logs_error_on_failure(
+    mock_run: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mock_run.side_effect = _make_called_process_error("activation oops")
+    caplog.set_level(logging.ERROR, logger="kindle_cap")
+    with pytest.raises(KindleActivationError):
+        activate_kindle()
+    assert "Kindle activation failed" in caplog.text
+    assert "activation oops" in caplog.text


### PR DESCRIPTION
## Summary

- `logging` モジュールを導入し、`kindle_cap` パッケージ全体に logger を配備
- subprocess の全箇所で stderr 握り潰しを解消（`activate_kindle` / `send_next_page` / `get_window_geometry` / `_run_oscript`）
- 新規 custom exception 3 種（`WindowGeometryError` / `KindleActivationError` / `KeystrokeError`）を追加
- ループ内例外時に `page N/M` + 撮影済み枚数 + out_dir を `logger.exception` で context 記録してから raise
- CLI に `--verbose` (`-v`) / `--quiet` (`-q`) / `--log-file PATH` を追加
- 既存 `print()` を全て `logger` に移行

Closes #62

## Background

2000 ページ撮影中の `osascript exit 1` クラッシュ時、stderr が握り潰されていて原因特定不可能だった。最小修正ではなくパッケージ全体の観測性を整備し直すことで、再発時に AppleScript の真エラーメッセージ + ページ番号 + 撮影済み枚数が log に残るようにした。

## Commits

1. `logging` 導入と CLI フラグ追加 (`--verbose`/`--quiet`/`--log-file`)
2. window.py の subprocess 観測性強化 (`WindowGeometryError` / `KindleActivationError`)
3. keys.py の subprocess 観測性強化 (`KeystrokeError`)
4. preflight.py / capture.py のロギング整備
5. orchestrator.py のループ context ロギング + print 全廃
6. cli.py の例外ハンドリングを logger 化 + 新規例外を捕捉
7. CHANGELOG 追記

## Test plan

- [x] `uv run pytest` 全 green (402 passed, 16 skipped — live マーカー付き integration)
- [x] `uv run ruff check src tests` 通過
- [x] `uv run ruff format --check src tests` 通過
- [x] `uv run mypy src` 通過（`tests/unit/test_book_ocr_preflight.py` の mypy エラーは main にも存在する既存問題、本 PR と無関係）
- [ ] CI green
- [ ] 意図的失敗トリガーで Kindle.app quit → AppleScript の stderr + ページ番号 + 撮影済み枚数が log に残ることを確認
